### PR TITLE
analysis: add global/built-in function support

### DIFF
--- a/internal/cli/loader.go
+++ b/internal/cli/loader.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"go.lsp.dev/protocol"
+
+	"github.com/tilt-dev/starlark-lsp/pkg/analysis"
+	"github.com/tilt-dev/starlark-lsp/pkg/document"
+)
+
+type Builtins struct {
+	Functions map[string]protocol.SignatureInformation
+	Symbols   []protocol.SymbolInformation
+}
+
+func LoadBuiltins(ctx context.Context, paths ...string) (Builtins, error) {
+	functions := make(map[string]protocol.SignatureInformation)
+	// TODO(milas): fix Symbol analysis query and include
+	var builtinSymbols []protocol.SymbolInformation
+
+	for _, path := range paths {
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			return Builtins{}, err
+		}
+
+		tree, err := analysis.Parse(ctx, contents)
+		if err != nil {
+			return Builtins{}, fmt.Errorf("failed to parse %q: %v", path, err)
+		}
+
+		doc := document.NewDocument(contents, tree)
+		docFunctions := analysis.Functions(doc, tree.RootNode())
+		// symbols := analysis.DocumentSymbols(doc)
+
+		for fn, sig := range docFunctions {
+			if _, ok := functions[fn]; ok {
+				return Builtins{}, fmt.Errorf("duplicate function %q found in %q", fn, path)
+			}
+			functions[fn] = sig
+		}
+	}
+
+	builtins := Builtins{
+		Functions: functions,
+		Symbols:   builtinSymbols,
+	}
+	return builtins, nil
+}

--- a/pkg/analysis/analyzer.go
+++ b/pkg/analysis/analyzer.go
@@ -1,0 +1,102 @@
+package analysis
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+	"go.lsp.dev/protocol"
+
+	"github.com/tilt-dev/starlark-lsp/pkg/document"
+)
+
+type Analyzer struct {
+	builtinFunctions map[string]protocol.SignatureInformation
+	builtinSymbols   []protocol.SymbolInformation
+}
+
+type AnalyzerOption func(*Analyzer)
+
+func NewAnalyzer(opts ...AnalyzerOption) *Analyzer {
+	analyzer := Analyzer{
+		builtinFunctions: make(map[string]protocol.SignatureInformation),
+	}
+	for _, opt := range opts {
+		opt(&analyzer)
+	}
+	return &analyzer
+}
+
+func WithBuiltinFunctions(sigs map[string]protocol.SignatureInformation) AnalyzerOption {
+	return func(analyzer *Analyzer) {
+		for fn, sig := range sigs {
+			analyzer.builtinFunctions[fn] = sig
+		}
+	}
+}
+
+func WithBuiltinSymbols(symbols []protocol.SymbolInformation) AnalyzerOption {
+	return func(analyzer *Analyzer) {
+		analyzer.builtinSymbols = append(analyzer.builtinSymbols, symbols...)
+	}
+}
+
+func (a *Analyzer) SignatureHelp(doc document.Document, pos protocol.Position) *protocol.SignatureHelp {
+	node, ok := NodeAtPosition(doc, pos)
+	if !ok {
+		return nil
+	}
+
+	fnName := possibleCallFunctionName(doc, node)
+	if fnName == "" {
+		// avoid computing function defs
+		return nil
+	}
+
+	for n := node; n != nil; n = n.Parent() {
+		sigs := Functions(doc, n)
+		if sig, ok := sigs[fnName]; ok {
+			// TODO(milas): determine active parameter based on position
+			return &protocol.SignatureHelp{
+				Signatures:      []protocol.SignatureInformation{sig},
+				ActiveSignature: 0,
+			}
+		}
+	}
+
+	if sig, ok := a.builtinFunctions[fnName]; ok {
+		// TODO(milas): determine active parameter based on position
+		return &protocol.SignatureHelp{
+			Signatures:      []protocol.SignatureInformation{sig},
+			ActiveSignature: 0,
+		}
+	}
+
+	return nil
+}
+
+// possibleCallFunctionName attempts to find the name of the function for a
+// `call`.
+//
+// Currently, this supports two cases:
+// 	(1) Current node is inside of a `call`
+// 	(2) Current node is inside of an ERROR block where first child is an
+// 		`identifier`
+func possibleCallFunctionName(doc document.Document, node *sitter.Node) string {
+	for n := node; n != nil; n = n.Parent() {
+		if n.Type() == "call" {
+			return n.ChildByFieldName("function").Content(doc.Contents)
+		}
+		if n.HasError() {
+			// look for `foo(` and assume it's a function call - this could
+			// happen if the closing `)` is not (yet) present or if there's
+			// something invalid going on within the params
+			possibleCall := n.NamedChild(0)
+			if possibleCall != nil && possibleCall.Type() == NodeTypeIdentifier {
+				possibleParen := possibleCall.NextSibling()
+				if possibleParen != nil && possibleParen.Content(doc.Contents) == "(" {
+					return possibleCall.Content(doc.Contents)
+				}
+			}
+			break
+		}
+	}
+	return ""
+}

--- a/pkg/analysis/loader/loader.go
+++ b/pkg/analysis/loader/loader.go
@@ -1,0 +1,1 @@
+package loader

--- a/pkg/server/fixture_test.go
+++ b/pkg/server/fixture_test.go
@@ -47,7 +47,8 @@ func newFixture(t testing.TB) *fixture {
 	client := protocol.ClientDispatcher(serverJsonConn, logger.Named("client"))
 
 	docManager := document.NewDocumentManager()
-	s := server.NewServer(docManager, client)
+	analyzer := analysis.NewAnalyzer()
+	s := server.NewServer(client, docManager, analyzer)
 
 	// TODO(milas): AsyncHandler does not stop if the server is shut down which
 	// 	can cause panics in tests (due to logs being emitted after tests are

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4,6 +4,7 @@ import (
 	"go.lsp.dev/jsonrpc2"
 	"go.lsp.dev/protocol"
 
+	"github.com/tilt-dev/starlark-lsp/pkg/analysis"
 	"github.com/tilt-dev/starlark-lsp/pkg/document"
 	"github.com/tilt-dev/starlark-lsp/pkg/middleware"
 )
@@ -14,16 +15,19 @@ type Server struct {
 	// implementations
 	FallbackServer
 
-	// docs tracks open files for the editor including their contents and parse tree
-	docs *document.Manager
 	// notifier can send broadcasts to the editor (e.g. diagnostics)
 	notifier protocol.Client
+	// docs tracks open files for the editor including their contents and parse tree
+	docs *document.Manager
+	// analyzer performs queries on Document objects to build LSP responses
+	analyzer *analysis.Analyzer
 }
 
-func NewServer(docManager *document.Manager, notifier protocol.Client) *Server {
+func NewServer(notifier protocol.Client, docManager *document.Manager, analyzer *analysis.Analyzer) *Server {
 	return &Server{
-		docs:     docManager,
 		notifier: notifier,
+		docs:     docManager,
+		analyzer: analyzer,
 	}
 }
 

--- a/pkg/server/signature.go
+++ b/pkg/server/signature.go
@@ -4,73 +4,16 @@ import (
 	"context"
 
 	"go.lsp.dev/protocol"
-	"go.uber.org/zap"
-
-	"github.com/tilt-dev/starlark-lsp/pkg/analysis"
 )
 
-func (s *Server) SignatureHelp(ctx context.Context,
+func (s *Server) SignatureHelp(_ context.Context,
 	params *protocol.SignatureHelpParams) (*protocol.SignatureHelp, error) {
 
-	uri := params.TextDocument.URI
-	logger := protocol.LoggerFromContext(ctx).
-		With(zap.String("uri", string(uri)))
-
-	doc, err := s.docs.Read(uri)
+	doc, err := s.docs.Read(params.TextDocument.URI)
 	if err != nil {
 		return nil, err
 	}
 	defer doc.Close()
 
-	node, ok := analysis.NodeAtPosition(doc, params.Position)
-	if !ok {
-		logger.Debug("no node at current editor position", positionField(params.Position))
-	}
-
-	// determine the function name we want a signature for; if we can't find
-	// one, return early to avoid unnecessarily determining all functions in
-	// scope
-	// currently, this supports two cases:
-	// 	(1) current node is inside of a `call`
-	// 	(2) current node is inside of an ERROR block where first child is an
-	// 		`identifier`
-	var candidateFunctionName string
-	for n := node; n != nil; n = n.Parent() {
-		if n.Type() == "call" {
-			candidateFunctionName = n.ChildByFieldName("function").Content(doc.Contents)
-			break
-		}
-		if n.HasError() {
-			// look for `foo(` and assume it's a function call - this could
-			// happen if the closing `)` is not (yet) present or if there's
-			// something invalid going on within the params
-			possibleCall := n.NamedChild(0)
-			if possibleCall != nil && possibleCall.Type() == analysis.NodeTypeIdentifier {
-				possibleParen := possibleCall.NextSibling()
-				if possibleParen != nil && possibleParen.Content(doc.Contents) == "(" {
-					candidateFunctionName = possibleCall.Content(doc.Contents)
-				}
-			}
-			break
-		}
-	}
-	if candidateFunctionName == "" {
-		logger.Debug("no call node in current tree")
-		return &protocol.SignatureHelp{}, nil
-	}
-
-	sigs := analysis.Functions(doc, node)
-	sig, ok := sigs[candidateFunctionName]
-	if !ok {
-		logger.Debug("no signature found", zap.String("function", candidateFunctionName))
-		return &protocol.SignatureHelp{}, nil
-	}
-
-	// TODO(milas): determine active parameter based on position
-	resp := &protocol.SignatureHelp{
-		Signatures:      []protocol.SignatureInformation{sig},
-		ActiveSignature: 0,
-	}
-
-	return resp, nil
+	return s.analyzer.SignatureHelp(doc, params.Position), nil
 }


### PR DESCRIPTION
The `Analyzer` is a semi-stateful type to handle analysis for a
workspace. Currently, the only "state" it has is built-in functions
and symbols, which can be registered with it at construction.

For generic CLI usage, the `--builtin-paths` can be used to pass
Starlark/Python3 (including type hints) stub files, which will be
parsed at startup and treated as globals.

In the future, the `Analyzer` can/should handle cross-document
analysis/resolutions as well. This is in contrast to the purely
functional analysis methods that only consider a local Tree-sitter
(sub)tree.