### PR TITLE
analysis: clean up signature/parameter extraction

### DIFF
--- a/pkg/analysis/analyzer.go
+++ b/pkg/analysis/analyzer.go
@@ -51,8 +51,8 @@ func (a *Analyzer) SignatureHelp(doc document.Document, pos protocol.Position) *
 	}
 
 	for n := node; n != nil; n = n.Parent() {
-		sigs := Functions(doc, n)
-		if sig, ok := sigs[fnName]; ok {
+		sig, ok := Function(doc, n, fnName)
+		if ok {
 			// TODO(milas): determine active parameter based on position
 			return &protocol.SignatureHelp{
 				Signatures:      []protocol.SignatureInformation{sig},

--- a/pkg/analysis/node.go
+++ b/pkg/analysis/node.go
@@ -10,10 +10,12 @@ import (
 const (
 	NodeTypeArgList     = "argument_list"
 	NodeTypeFunctionDef = "function_definition"
+	NodeTypeParameters  = "parameters"
 	NodeTypeIdentifier  = "identifier"
 
 	FieldName       = "name"
 	FieldParameters = "parameters"
+	FieldReturnType = "return_type"
 )
 
 // NodeAtPosition returns the most granular named descendant at a position.

--- a/pkg/analysis/params.go
+++ b/pkg/analysis/params.go
@@ -1,0 +1,68 @@
+package analysis
+
+import (
+	"fmt"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"go.lsp.dev/protocol"
+
+	"github.com/tilt-dev/starlark-lsp/pkg/document"
+	"github.com/tilt-dev/starlark-lsp/pkg/query"
+)
+
+type parameter struct {
+	name         string
+	typeHint     string
+	defaultValue string
+	content      string
+}
+
+func (p parameter) paramInfo() protocol.ParameterInformation {
+	return protocol.ParameterInformation{
+		Label: p.content,
+		// TODO(milas): this method should accept a docstring
+		Documentation: protocol.MarkupContent{
+			Kind: protocol.Markdown,
+		},
+	}
+}
+
+func extractParameters(doc document.Document, node *sitter.Node) []protocol.ParameterInformation {
+	if node.Type() != NodeTypeParameters {
+		// A query is used here because there's several different node types
+		// for parameter values, and the query handles normalization gracefully
+		// for us.
+		//
+		// Technically, the query will execute regardless of passed in node
+		// type, but since Tree-sitter doesn't currently support bounding query
+		// depth, that could result in finding parameters from funcs in nested
+		// scopes if a block was passed, so this ensures that the actual
+		// `parameters` node is passed in here.
+		//
+		// See https://github.com/tree-sitter/tree-sitter/issues/1212
+		panic(fmt.Errorf("invalid node type: %v", node.Type()))
+	}
+
+	var params []protocol.ParameterInformation
+	Query(node, query.FunctionParameters, func(q *sitter.Query, match *sitter.QueryMatch) bool {
+		var param parameter
+
+		for _, c := range match.Captures {
+			content := c.Node.Content(doc.Contents)
+			switch q.CaptureNameForId(c.Index) {
+			case "name":
+				param.name = content
+			case "type":
+				param.typeHint = content
+			case "value":
+				param.defaultValue = content
+			case "param":
+				param.content = content
+			}
+		}
+
+		params = append(params, param.paramInfo())
+		return true
+	})
+	return params
+}

--- a/pkg/analysis/parse.go
+++ b/pkg/analysis/parse.go
@@ -2,15 +2,12 @@ package analysis
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
 	"github.com/smacker/go-tree-sitter/python"
 	"go.lsp.dev/protocol"
 
 	"github.com/tilt-dev/starlark-lsp/pkg/document"
-	"github.com/tilt-dev/starlark-lsp/pkg/query"
 )
 
 var lang = python.GetLanguage()
@@ -57,48 +54,4 @@ func DocumentSymbols(doc document.Document) []protocol.SymbolInformation {
 	}
 
 	return symbols
-}
-
-func Functions(doc document.Document, node *sitter.Node) map[string]protocol.SignatureInformation {
-	signatures := make(map[string]protocol.SignatureInformation)
-	for _, n := range nodePathTopDown(node) {
-		scopeSigs := functionsForDirectScope(doc, n)
-		for fn, sig := range scopeSigs {
-			signatures[fn] = sig
-		}
-	}
-	return signatures
-}
-
-func functionsForDirectScope(doc document.Document, node *sitter.Node) map[string]protocol.SignatureInformation {
-	signatures := make(map[string]protocol.SignatureInformation)
-	for n := node.NamedChild(0); n != nil; n = n.NextNamedSibling() {
-		if n.Type() != NodeTypeFunctionDef {
-			continue
-		}
-
-		fnName := n.ChildByFieldName(FieldName).Content(doc.Contents)
-		var signature protocol.SignatureInformation
-		var rawParams []string
-		Query(n, query.FunctionParameters, func(q *sitter.Query, match *sitter.QueryMatch) {
-			var param protocol.ParameterInformation
-
-			for _, c := range match.Captures {
-				// TODO(milas): use type + default (if available) in label
-				switch q.CaptureNameForId(c.Index) {
-				case "param":
-					label := c.Node.Content(doc.Contents)
-					param.Label = label
-					rawParams = append(rawParams, label)
-				}
-			}
-
-			signature.Parameters = append(signature.Parameters, param)
-		})
-
-		signature.Label = fmt.Sprintf("%s(%s)", fnName, strings.Join(rawParams, ", "))
-		signatures[fnName] = signature
-	}
-
-	return signatures
 }

--- a/pkg/analysis/query.go
+++ b/pkg/analysis/query.go
@@ -15,9 +15,11 @@ func mustQuery(pattern []byte) *sitter.Query {
 	return q
 }
 
+type QueryMatchFunc func(q *sitter.Query, match *sitter.QueryMatch) bool
+
 // Query executes a Tree-sitter S-expression query against a subtree and invokes
 // matchFn on each result.
-func Query(node *sitter.Node, pattern []byte, matchFn func(q *sitter.Query, match *sitter.QueryMatch)) {
+func Query(node *sitter.Node, pattern []byte, matchFn QueryMatchFunc) {
 	q := mustQuery(pattern)
 	qc := sitter.NewQueryCursor()
 	defer qc.Close()
@@ -27,6 +29,8 @@ func Query(node *sitter.Node, pattern []byte, matchFn func(q *sitter.Query, matc
 		if m == nil {
 			panic("tree-sitter returned nil match")
 		}
-		matchFn(q, m)
+		if !matchFn(q, m) {
+			return
+		}
 	}
 }

--- a/pkg/analysis/signature.go
+++ b/pkg/analysis/signature.go
@@ -1,0 +1,92 @@
+package analysis
+
+import (
+	"fmt"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"go.lsp.dev/protocol"
+
+	"github.com/tilt-dev/starlark-lsp/pkg/document"
+)
+
+// Functions finds all function definitions that are direct children of the provided sitter.Node.
+func Functions(doc document.Document, node *sitter.Node) map[string]protocol.SignatureInformation {
+	signatures := make(map[string]protocol.SignatureInformation)
+
+	// N.B. we don't use a query here for a couple reasons:
+	// 	(1) Tree-sitter doesn't support bounding the depth, and we only want
+	//		direct descendants (to avoid matching on functions in nested scopes)
+	//		See https://github.com/tree-sitter/tree-sitter/issues/1212.
+	//	(2) function_definition nodes have named fields for what we care about,
+	//		which makes it easy to get the data without using a query to help
+	//		massage/standardize it (for example, we do this for params since
+	//		there are multiple type of param values)
+	for n := node.NamedChild(0); n != nil; n = n.NextNamedSibling() {
+		if n.Type() != NodeTypeFunctionDef {
+			continue
+		}
+		fnName, sig := extractSignatureInformation(doc, n)
+		signatures[fnName] = sig
+	}
+
+	return signatures
+}
+
+// Function finds a function definition for the given function name that is a direct child of the provided sitter.Node.
+func Function(doc document.Document, node *sitter.Node, fnName string) (protocol.SignatureInformation, bool) {
+	for n := node.NamedChild(0); n != nil; n = n.NextNamedSibling() {
+		if n.Type() != NodeTypeFunctionDef {
+			continue
+		}
+		curFuncName := n.ChildByFieldName(FieldName).Content(doc.Contents)
+		if curFuncName == fnName {
+			_, sig := extractSignatureInformation(doc, n)
+			return sig, true
+		}
+	}
+	return protocol.SignatureInformation{}, false
+}
+
+func extractSignatureInformation(doc document.Document, n *sitter.Node) (string, protocol.SignatureInformation) {
+	if n.Type() != NodeTypeFunctionDef {
+		panic(fmt.Errorf("invalid node type: %s", n.Type()))
+	}
+
+	fnName := n.ChildByFieldName(FieldName).Content(doc.Contents)
+	// params might be empty but a node for `()` will still exist
+	params := extractParameters(doc, n.ChildByFieldName(FieldParameters))
+	// unlike name + params, returnType is optional
+	var returnType string
+	if rtNode := n.ChildByFieldName(FieldReturnType); rtNode != nil {
+		returnType = rtNode.Content(doc.Contents)
+	}
+
+	sig := protocol.SignatureInformation{
+		Label:      signatureLabel(params, returnType),
+		Parameters: params,
+	}
+
+	return fnName, sig
+}
+
+// signatureLabel produces a human-readable label for a function signature.
+//
+// It's modeled to behave similarly to VSCode Python signature labels.
+func signatureLabel(params []protocol.ParameterInformation, returnType string) string {
+	if returnType == "" {
+		returnType = "None"
+	}
+
+	var sb strings.Builder
+	sb.WriteRune('(')
+	for i := range params {
+		sb.WriteString(params[i].Label)
+		if i != len(params)-1 {
+			sb.WriteString(", ")
+		}
+	}
+	sb.WriteString(") -> ")
+	sb.WriteString(returnType)
+	return sb.String()
+}

--- a/pkg/server/signature_test.go
+++ b/pkg/server/signature_test.go
@@ -16,7 +16,7 @@ func TestServer_SignatureHelp(t *testing.T) {
 
 	src := `
 def foo():
-  def foo(a, b: str, c=None, d: int=5):
+  def foo(a, b: str, c=None, d: int=5) -> List[str]:
     foo()
 `
 
@@ -32,7 +32,7 @@ def foo():
 
 	require.Len(t, resp.Signatures, 1)
 	assert.Equal(t, uint32(0), resp.ActiveSignature)
-	assert.Equal(t, "foo(a, b: str, c=None, d: int=5)", resp.Signatures[0].Label)
+	assert.Equal(t, "(a, b: str, c=None, d: int=5) -> List[str]", resp.Signatures[0].Label)
 }
 
 func TestServer_SignatureHelp_ErrorAtCursor(t *testing.T) {
@@ -59,7 +59,7 @@ foo(
 
 	require.Len(t, resp.Signatures, 1)
 	assert.Equal(t, uint32(0), resp.ActiveSignature)
-	assert.Equal(t, "foo()", resp.Signatures[0].Label)
+	assert.Equal(t, "() -> None", resp.Signatures[0].Label)
 }
 
 func TestServer_SignatureHelp_OutOfScope(t *testing.T) {


### PR DESCRIPTION
* Add `Function()` to find a specific function in current direct
  scope
* Make labels more consistent with VSCode Python extension
* Re-organize code into separate files & add godoc