### PR TITLE
document: add leak checker to server tests

### DIFF
--- a/internal/cli/loader.go
+++ b/internal/cli/loader.go
@@ -35,6 +35,7 @@ func LoadBuiltins(ctx context.Context, paths ...string) (Builtins, error) {
 		doc := document.NewDocument(contents, tree)
 		docFunctions := query.Functions(doc, tree.RootNode())
 		// symbols := analysis.DocumentSymbols(doc)
+		doc.Close()
 
 		for fn, sig := range docFunctions {
 			if _, ok := functions[fn]; ok {

--- a/pkg/analysis/analyzer.go
+++ b/pkg/analysis/analyzer.go
@@ -92,7 +92,7 @@ func possibleCallInfo(doc document.Document, node *sitter.Node,
 	pos protocol.Position) (fnName string, argIndex uint32) {
 	for n := node; n != nil; n = n.Parent() {
 		if n.Type() == "call" {
-			fnName = n.ChildByFieldName("function").Content(doc.Contents)
+			fnName = doc.Content(n.ChildByFieldName("function"))
 			argIndex = possibleActiveParam(doc, n.ChildByFieldName("arguments").Child(0), pos)
 			return fnName, argIndex
 		} else if n.HasError() {
@@ -102,8 +102,8 @@ func possibleCallInfo(doc document.Document, node *sitter.Node,
 			possibleCall := n.NamedChild(0)
 			if possibleCall != nil && possibleCall.Type() == query.NodeTypeIdentifier {
 				possibleParen := possibleCall.NextSibling()
-				if possibleParen != nil && !possibleParen.IsNamed() && possibleParen.Content(doc.Contents) == "(" {
-					fnName = possibleCall.Content(doc.Contents)
+				if possibleParen != nil && !possibleParen.IsNamed() && doc.Content(possibleParen) == "(" {
+					fnName = doc.Content(possibleCall)
 					argIndex = possibleActiveParam(doc, possibleParen.NextSibling(), pos)
 					return fnName, argIndex
 				}
@@ -123,7 +123,7 @@ func possibleActiveParam(doc document.Document, node *sitter.Node, pos protocol.
 			break
 		}
 
-		if !n.IsNamed() && n.Content(doc.Contents) == "," {
+		if !n.IsNamed() && doc.Content(n) == "," {
 			argIndex++
 		}
 	}

--- a/pkg/query/location.go
+++ b/pkg/query/location.go
@@ -26,10 +26,10 @@ func PointToPosition(point sitter.Point) protocol.Position {
 // NamedNodeAtPosition returns the most granular named descendant at a position.
 func NamedNodeAtPosition(doc document.Document, pos protocol.Position) (*sitter.Node, bool) {
 	pt := PositionToPoint(pos)
-	if doc.Tree == nil {
+	if doc.Tree() == nil {
 		return nil, false
 	}
-	node := doc.Tree.RootNode().NamedDescendantForPointRange(pt, pt)
+	node := doc.Tree().RootNode().NamedDescendantForPointRange(pt, pt)
 	if node != nil {
 		return node, true
 	}

--- a/pkg/query/params.go
+++ b/pkg/query/params.go
@@ -68,7 +68,7 @@ func extractParameters(doc document.Document, fnDocs docstring.Parsed,
 		var param parameter
 
 		for _, c := range match.Captures {
-			content := c.Node.Content(doc.Contents)
+			content := doc.Content(c.Node)
 			switch q.CaptureNameForId(c.Index) {
 			case "name":
 				param.name = content

--- a/pkg/query/signature.go
+++ b/pkg/query/signature.go
@@ -41,7 +41,7 @@ func Function(doc document.Document, node *sitter.Node, fnName string) (protocol
 		if n.Type() != NodeTypeFunctionDef {
 			continue
 		}
-		curFuncName := n.ChildByFieldName(FieldName).Content(doc.Contents)
+		curFuncName := doc.Content(n.ChildByFieldName(FieldName))
 		if curFuncName == fnName {
 			_, sig := extractSignatureInformation(doc, n)
 			return sig, true
@@ -55,7 +55,7 @@ func extractSignatureInformation(doc document.Document, n *sitter.Node) (string,
 		panic(fmt.Errorf("invalid node type: %s", n.Type()))
 	}
 
-	fnName := n.ChildByFieldName(FieldName).Content(doc.Contents)
+	fnName := doc.Content(n.ChildByFieldName(FieldName))
 	fnDocs := extractDocstring(doc, n.ChildByFieldName(FieldBody))
 
 	// params might be empty but a node for `()` will still exist
@@ -63,7 +63,7 @@ func extractSignatureInformation(doc document.Document, n *sitter.Node) (string,
 	// unlike name + params, returnType is optional
 	var returnType string
 	if rtNode := n.ChildByFieldName(FieldReturnType); rtNode != nil {
-		returnType = rtNode.Content(doc.Contents)
+		returnType = doc.Content(rtNode)
 	}
 
 	sig := protocol.SignatureInformation{
@@ -112,7 +112,7 @@ func extractDocstring(doc document.Document, n *sitter.Node) docstring.Parsed {
 			// TODO(milas): need to do nested quote un-escaping (generally
 			// 	docstrings use triple-quoted strings so this isn't a huge
 			// 	issue at least)
-			rawDocString := docStringNode.Content(doc.Contents)
+			rawDocString := doc.Content(docStringNode)
 			// this is the raw source, so it will be wrapped with with """ / ''' / " / '
 			// (technically this could trim off too much but not worth the
 			// headache to deal with valid leading/trailing quotes)

--- a/pkg/query/symbol.go
+++ b/pkg/query/symbol.go
@@ -10,7 +10,7 @@ import (
 // TODO(milas): this currently only looks for assignment expressions
 func DocumentSymbols(doc document.Document) []protocol.SymbolInformation {
 	var symbols []protocol.SymbolInformation
-	for n := doc.Tree.RootNode().NamedChild(0); n != nil; n = n.NextNamedSibling() {
+	for n := doc.Tree().RootNode().NamedChild(0); n != nil; n = n.NextNamedSibling() {
 		var symbol protocol.SymbolInformation
 
 		if n.Type() == "expression_statement" {
@@ -18,7 +18,7 @@ func DocumentSymbols(doc document.Document) []protocol.SymbolInformation {
 			if assignment == nil || assignment.Type() != "assignment" {
 				continue
 			}
-			symbol.Name = assignment.ChildByFieldName("left").Content(doc.Contents)
+			symbol.Name = doc.Content(assignment.ChildByFieldName("left"))
 			kind := nodeTypeToSymbolKind(assignment.ChildByFieldName("right"))
 			if kind == 0 {
 				kind = protocol.SymbolKindVariable

--- a/pkg/server/signature_test.go
+++ b/pkg/server/signature_test.go
@@ -20,7 +20,7 @@ def foo():
     foo(a,,)
 `
 
-	f.loadDocument("./test.star", src)
+	f.mustWriteDocument("./test.star", src)
 
 	var resp protocol.SignatureHelp
 	f.mustEditorCall(protocol.MethodTextDocumentSignatureHelp, protocol.SignatureHelpParams{
@@ -63,7 +63,7 @@ def foo(a, b):
 foo(a,
 `
 
-	f.loadDocument("./test.star", src)
+	f.mustWriteDocument("./test.star", src)
 
 	var resp protocol.SignatureHelp
 	f.mustEditorCall(protocol.MethodTextDocumentSignatureHelp, protocol.SignatureHelpParams{
@@ -106,7 +106,7 @@ def foo():
 bar()
 `
 
-	f.loadDocument("./test.star", src)
+	f.mustWriteDocument("./test.star", src)
 
 	var resp protocol.SignatureHelp
 	f.mustEditorCall(protocol.MethodTextDocumentSignatureHelp, protocol.SignatureHelpParams{

--- a/pkg/server/symbol.go
+++ b/pkg/server/symbol.go
@@ -15,6 +15,7 @@ func (s *Server) DocumentSymbol(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	defer doc.Close()
 
 	symbols := query.DocumentSymbols(doc)
 	result := make([]interface{}, len(symbols))

--- a/pkg/server/symbol_test.go
+++ b/pkg/server/symbol_test.go
@@ -18,7 +18,7 @@ y = None
 z = True
 `
 
-	f.loadDocument("./test.star", doc)
+	f.mustWriteDocument("./test.star", doc)
 
 	var resp []protocol.DocumentSymbol
 	f.mustEditorCall(protocol.MethodTextDocumentDocumentSymbol, protocol.DocumentSymbolParams{

--- a/pkg/server/text_document_sync.go
+++ b/pkg/server/text_document_sync.go
@@ -6,7 +6,6 @@ import (
 
 	"go.lsp.dev/protocol"
 
-	"github.com/tilt-dev/starlark-lsp/pkg/document"
 	"github.com/tilt-dev/starlark-lsp/pkg/query"
 )
 
@@ -18,8 +17,7 @@ func (s *Server) DidOpen(ctx context.Context, params *protocol.DidOpenTextDocume
 		return fmt.Errorf("could not parse file %q: %v", uri, err)
 	}
 
-	doc := document.NewDocument(contents, tree)
-	s.docs.Write(uri, doc)
+	s.docs.Write(uri, contents, tree)
 	return nil
 }
 
@@ -36,8 +34,7 @@ func (s *Server) DidChange(ctx context.Context, params *protocol.DidChangeTextDo
 		return fmt.Errorf("could not parse file %q: %v", uri, err)
 	}
 
-	doc := document.NewDocument(contents, tree)
-	s.docs.Write(uri, doc)
+	s.docs.Write(uri, contents, tree)
 	return nil
 }
 
@@ -49,8 +46,7 @@ func (s *Server) DidSave(ctx context.Context, params *protocol.DidSaveTextDocume
 		return fmt.Errorf("could not parse file %q: %v", uri, err)
 	}
 
-	doc := document.NewDocument(contents, tree)
-	s.docs.Write(uri, doc)
+	s.docs.Write(uri, contents, tree)
 	return nil
 }
 

--- a/pkg/server/text_document_sync_test.go
+++ b/pkg/server/text_document_sync_test.go
@@ -22,10 +22,7 @@ func TestServer_DidOpen(t *testing.T) {
 		},
 	}, &resp)
 
-	doc, err := f.docManager.Read(uri.File("./test.star"))
-	require.NoError(t, err, "Failed to read file from doc manager")
-	require.Equal(t, fileData, string(doc.Contents), "File contents did not match")
-	require.NotNil(t, doc.Tree, "Tree-sitter tree was nil")
+	f.requireDocContents("./test.star", fileData)
 }
 
 func TestServer_DidChange(t *testing.T) {
@@ -46,10 +43,7 @@ func TestServer_DidChange(t *testing.T) {
 		},
 	}, &resp)
 
-	doc, err := f.docManager.Read(uri.File("./test.star"))
-	require.NoError(t, err, "Failed to read file from doc manager")
-	require.Equal(t, fileData, string(doc.Contents), "File contents did not match")
-	require.NotNil(t, doc.Tree, "Tree-sitter tree was nil")
+	f.requireDocContents("./test.star", fileData)
 }
 
 func TestServer_DidSave(t *testing.T) {
@@ -65,10 +59,7 @@ func TestServer_DidSave(t *testing.T) {
 		Text: fileData,
 	}, &resp)
 
-	doc, err := f.docManager.Read(uri.File("./test.star"))
-	require.NoError(t, err, "Failed to read file from doc manager")
-	require.Equal(t, fileData, string(doc.Contents), "File contents did not match")
-	require.NotNil(t, doc.Tree, "Tree-sitter tree was nil")
+	f.requireDocContents("./test.star", fileData)
 }
 
 func TestServer_DidClose(t *testing.T) {
@@ -76,24 +67,14 @@ func TestServer_DidClose(t *testing.T) {
 
 	const fileData = "foo + 1 = &^ 3"
 
+	f.mustWriteDocument("./test.star", fileData)
+
 	var resp jsonrpc2.Response
-	f.mustEditorCall(protocol.MethodTextDocumentDidOpen, protocol.DidOpenTextDocumentParams{
-		TextDocument: protocol.TextDocumentItem{
-			URI:  uri.File("./test.star"),
-			Text: fileData,
-		},
-	}, &resp)
-
-	doc, err := f.docManager.Read(uri.File("./test.star"))
-	require.NoError(t, err, "Failed to read file from doc manager")
-	require.Equal(t, fileData, string(doc.Contents), "File contents did not match")
-	require.NotNil(t, doc.Tree, "Tree-sitter tree was nil")
-
 	f.mustEditorCall(protocol.MethodTextDocumentDidClose, protocol.DidCloseTextDocumentParams{
 		TextDocument: protocol.TextDocumentIdentifier{URI: uri.File("./test.star")},
 	}, &resp)
 
-	doc, err = f.docManager.Read(uri.File("./test.star"))
+	doc, err := f.docManager.Read(uri.File("./test.star"))
 	require.EqualError(t, err, "file does not exist", "Document should no longer exist")
 	require.Zero(t, doc, "Document was not zero-value")
 }


### PR DESCRIPTION
It's easy to leak Tree-sitter tree objects by forgetting to call
`Close()`. This is typically done by calling `Close()` on the
wrapping `Document` object.

To prevent this, `Document` is now an interface rather than a
struct, and a special implementation is used in tests that wraps
the real one but does some basic ref counting to ensure that they
are being properly closed and will fail a test if any are left
over at the end. (This does means tests need to remember to clean
up any docs they read manually and/or use helpers that do it for
them, e.g. `requireDocContents`.)