### PR TITLE
lsp: fix logging, more changes to allow calling as a library

### DIFF
--- a/pkg/cli/logging.go
+++ b/pkg/cli/logging.go
@@ -6,13 +6,17 @@ import (
 	"go.uber.org/zap"
 )
 
-func mustInitializeLogger(level zap.AtomicLevel) *zap.Logger {
+func NewLogger() (logger *zap.Logger, cleanup func()) {
 	cfg := zap.NewDevelopmentConfig()
-	cfg.Level = level
+	cfg.Level = logLevel
 	cfg.Development = false
 	logger, err := cfg.Build()
 	if err != nil {
 		panic(fmt.Errorf("failed to initialize logger: %v", err))
 	}
-	return logger
+
+	cleanup = func() {
+		_ = logger.Sync()
+	}
+	return logger, cleanup
 }


### PR DESCRIPTION
#14 mostly worked, but it turned out if you ran `tilt lsp`, instead of getting usage showing you `tilt lsp start`, it just hung, because we were defining a `Run` on `lsp`. Also it broke logging even when running from this repo.

Making loglevel global is unfortunate, but:
1) cobra's support for context is pretty poor
2) cobra leans heavily into globals and trying to avoid them can sometimes really feel like swimming upstream

TLDR is: we need to create the log level when initializing the context and to update the log level in PreRun, but PreRun doesn't have access to initialize a context. There might be a way to do this without a global, but I've probably already spent too much time on that.