### PR TITLE
lsp: use plaintext instead of markdown

### DIFF
--- a/pkg/query/params.go
+++ b/pkg/query/params.go
@@ -38,7 +38,7 @@ func (p parameter) paramInfo(fnDocs docstring.Parsed) protocol.ParameterInformat
 
 	if docContent != "" {
 		pi.Documentation = protocol.MarkupContent{
-			Kind:  protocol.Markdown,
+			Kind:  protocol.PlainText,
 			Value: docContent,
 		}
 	}

--- a/pkg/query/signature.go
+++ b/pkg/query/signature.go
@@ -73,7 +73,7 @@ func extractSignatureInformation(doc document.Document, n *sitter.Node) (string,
 
 	if fnDocs.Description != "" {
 		sig.Documentation = protocol.MarkupContent{
-			Kind:  protocol.Markdown,
+			Kind:  protocol.PlainText,
 			Value: fnDocs.Description,
 		}
 	}


### PR DESCRIPTION
WDYT? Or maybe there is some other ugliness this introduces?

The `# comments` in examples in the api docs get rendered as headers in markdown, which are exceedingly ugly:
<img width="353" alt="image" src="https://user-images.githubusercontent.com/7453991/158668605-8becccc4-69cb-4d54-ad2d-3db4563c49e6.png">

Rendering as plaintext makes the `... code-block::`s visible, but that seems less ugly?
<img width="346" alt="image" src="https://user-images.githubusercontent.com/7453991/158668742-3f54a165-b1de-4ecc-8a10-a2a1d988237d.png">

NB: this change also means backticks don't get special rendering. I don't think this is a big loss for code since the special rendering isn't very distinctive anyway and the literal `` feels clearer. Links are messed up either way and will be until we move docs off of rst.

Before:
<img width="353" alt="image" src="https://user-images.githubusercontent.com/7453991/158668986-60681e44-ae32-41cd-a1bb-c3df664b5fc1.png">

After:
<img width="356" alt="image" src="https://user-images.githubusercontent.com/7453991/158668863-cb961a1a-daad-403f-ae3d-4cab59d47f29.png">
