### PR TITLE
Follow load statements for symbols and functions

### DIFF
--- a/pkg/analysis/builtins.go
+++ b/pkg/analysis/builtins.go
@@ -116,7 +116,7 @@ func LoadBuiltinsFromSource(ctx context.Context, contents []byte, path string) (
 	}
 
 	functions := make(map[string]protocol.SignatureInformation)
-	doc := document.NewDocumentWithSymbols(uri.File(path), contents, tree)
+	doc := document.NewDocument(uri.File(path), contents, tree)
 	docFunctions := doc.Functions()
 	symbols := doc.Symbols()
 	doc.Close()

--- a/pkg/analysis/builtins.go
+++ b/pkg/analysis/builtins.go
@@ -115,9 +115,9 @@ func LoadBuiltinsFromSource(ctx context.Context, contents []byte, path string) (
 	}
 
 	functions := make(map[string]protocol.SignatureInformation)
-	doc := document.NewDocument(contents, tree)
-	docFunctions := query.Functions(doc, tree.RootNode())
-	symbols := query.DocumentSymbols(doc)
+	doc := document.NewDocumentWithSymbols(contents, tree)
+	docFunctions := doc.Functions()
+	symbols := doc.Symbols()
 	doc.Close()
 
 	for fn, sig := range docFunctions {

--- a/pkg/analysis/builtins.go
+++ b/pkg/analysis/builtins.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 
 	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
 
 	"github.com/tilt-dev/starlark-lsp/pkg/document"
 	"github.com/tilt-dev/starlark-lsp/pkg/query"
@@ -115,7 +116,7 @@ func LoadBuiltinsFromSource(ctx context.Context, contents []byte, path string) (
 	}
 
 	functions := make(map[string]protocol.SignatureInformation)
-	doc := document.NewDocumentWithSymbols(contents, tree)
+	doc := document.NewDocumentWithSymbols(uri.File(path), contents, tree)
 	docFunctions := doc.Functions()
 	symbols := doc.Symbols()
 	doc.Close()

--- a/pkg/analysis/builtins_test.go
+++ b/pkg/analysis/builtins_test.go
@@ -246,7 +246,7 @@ func (f *fixture) Symbol(name string) protocol.DocumentSymbol {
 
 func (f *fixture) Document(content string) {
 	tree, _ := query.Parse(f.ctx, []byte(content))
-	doc := document.NewDocumentWithSymbols([]byte(content), tree)
+	doc := document.NewDocumentWithSymbols("", []byte(content), tree)
 	f.t.Cleanup(func() { doc.Close() })
 	f.doc = doc
 }

--- a/pkg/analysis/builtins_test.go
+++ b/pkg/analysis/builtins_test.go
@@ -246,7 +246,7 @@ func (f *fixture) Symbol(name string) protocol.DocumentSymbol {
 
 func (f *fixture) Document(content string) {
 	tree, _ := query.Parse(f.ctx, []byte(content))
-	doc := document.NewDocument([]byte(content), tree)
+	doc := document.NewDocumentWithSymbols([]byte(content), tree)
 	f.t.Cleanup(func() { doc.Close() })
 	f.doc = doc
 }

--- a/pkg/analysis/builtins_test.go
+++ b/pkg/analysis/builtins_test.go
@@ -246,7 +246,7 @@ func (f *fixture) Symbol(name string) protocol.DocumentSymbol {
 
 func (f *fixture) Document(content string) {
 	tree, _ := query.Parse(f.ctx, []byte(content))
-	doc := document.NewDocumentWithSymbols("", []byte(content), tree)
+	doc := document.NewDocument("", []byte(content), tree)
 	f.t.Cleanup(func() { doc.Close() })
 	f.doc = doc
 }

--- a/pkg/analysis/completion.go
+++ b/pkg/analysis/completion.go
@@ -128,8 +128,10 @@ func (a *Analyzer) completeExpression(doc document.Document, nodes []*sitter.Nod
 
 // Returns a list of available symbols for completion as follows:
 // - If in a function argument list, include keyword args for that function
-// - Add symbols in scope for the node at point
-// - Add document symbols, excluding symbols after the node if the node is in the module scope
+// - Add symbols in scope for the node at point, excluding symbols at the module
+//   level (document symbols), because the document already has those computed
+// - Add document symbols, but only symbols defined before the node at point if the node
+//   is in the module scope (not inside a function).
 // - Add builtins
 func (a *Analyzer) availableSymbols(doc document.Document, nodeAtPoint *sitter.Node, pt sitter.Point) []protocol.DocumentSymbol {
 	symbols := []protocol.DocumentSymbol{}

--- a/pkg/analysis/completion.go
+++ b/pkg/analysis/completion.go
@@ -130,12 +130,10 @@ func (a *Analyzer) completeExpression(doc document.Document, nodes []*sitter.Nod
 // - If in a function argument list, include keyword args for that function
 // - Add symbols in scope for the node at point, excluding symbols at the module
 //   level (document symbols), because the document already has those computed
-// - Add document symbols, but only symbols defined before the node at point if the node
-//   is in the module scope (not inside a function).
+// - Add document symbols
 // - Add builtins
 func (a *Analyzer) availableSymbols(doc document.Document, nodeAtPoint *sitter.Node, pt sitter.Point) []protocol.DocumentSymbol {
 	symbols := []protocol.DocumentSymbol{}
-	var moduleNode *sitter.Node
 	if nodeAtPoint != nil {
 		if fnName, args := keywordArgContext(doc, nodeAtPoint, pt); fnName != "" {
 			if fn, ok := a.signatureInformation(doc, nodeAtPoint, fnName); ok {
@@ -143,12 +141,8 @@ func (a *Analyzer) availableSymbols(doc document.Document, nodeAtPoint *sitter.N
 			}
 		}
 		symbols = append(symbols, query.SymbolsInScope(doc, nodeAtPoint)...)
-		if query.IsModuleScope(doc, nodeAtPoint) {
-			moduleNode = nodeAtPoint
-		}
 	}
-	docAndBuiltin := query.SymbolsBefore(doc.Symbols(), moduleNode)
-	docAndBuiltin = append(docAndBuiltin, a.builtins.Symbols...)
+	docAndBuiltin := append(doc.Symbols(), a.builtins.Symbols...)
 	for _, sym := range docAndBuiltin {
 		found := false
 		for _, s := range symbols {

--- a/pkg/analysis/completion_test.go
+++ b/pkg/analysis/completion_test.go
@@ -60,10 +60,8 @@ def f2():
 
 # <- position 1
 
-#^- position 3
-
 if True:
-    # position 4
+    # position 3
 	pass
 
 t = 1234
@@ -91,13 +89,11 @@ func TestCompletions(t *testing.T) {
 		{doc: "os.e", char: 4, expected: []string{"environ"}, osSys: true},
 
 		// position 1
-		{doc: docWithMultiplePlaces, line: 10, expected: []string{"f1", "s", "f2", "os", "sys"}, osSys: true},
+		{doc: docWithMultiplePlaces, line: 10, expected: []string{"f1", "s", "f2", "t", "os", "sys"}, osSys: true},
 		// position 2
 		{doc: docWithMultiplePlaces, line: 7, char: 4, expected: []string{"f1", "s", "f2", "t", "os", "sys"}, osSys: true},
 		// position 3
-		{doc: docWithMultiplePlaces, line: 11, expected: []string{"f1", "s", "f2", "os", "sys"}, osSys: true},
-		// position 4
-		{doc: docWithMultiplePlaces, line: 15, char: 4, expected: []string{"f1", "s", "f2", "os", "sys"}, osSys: true},
+		{doc: docWithMultiplePlaces, line: 13, char: 4, expected: []string{"f1", "s", "f2", "t", "os", "sys"}, osSys: true},
 		{doc: docWithErrorNode, line: 4, char: 1, expected: []string{"foo"}, osSys: true},
 		// inside string
 		{doc: `f = "abc123"`, char: 5, expected: []string{}, osSys: true},
@@ -109,7 +105,7 @@ func TestCompletions(t *testing.T) {
 		{doc: `T`, char: 1, expected: []string{"True"}, builtin: true},
 		{doc: `F`, char: 1, expected: []string{"False"}, builtin: true},
 		// inside function body
-		{doc: "def fn():\n  \nx = True", line: 1, char: 2, expected: []string{"fn", "os", "sys"}, osSys: true},
+		{doc: "def fn():\n  \nx = True", line: 1, char: 2, expected: []string{"fn", "x", "os", "sys"}, osSys: true},
 		{doc: "def fn():\n  a = 1\n  \n  \b  b = 2\n  return b\nx = True", line: 2, char: 2, expected: []string{"a", "fn", "os", "sys", "x"}, osSys: true},
 		// inside a list
 		{doc: "x = [os.]", char: 8, expected: []string{"environ", "name"}, osSys: true},

--- a/pkg/analysis/completion_test.go
+++ b/pkg/analysis/completion_test.go
@@ -110,6 +110,7 @@ func TestCompletions(t *testing.T) {
 		{doc: `F`, char: 1, expected: []string{"False"}, builtin: true},
 		// inside function body
 		{doc: "def fn():\n  \nx = True", line: 1, char: 2, expected: []string{"fn", "os", "sys"}, osSys: true},
+		{doc: "def fn():\n  a = 1\n  \n  \b  b = 2\n  return b\nx = True", line: 2, char: 2, expected: []string{"a", "fn", "os", "sys", "x"}, osSys: true},
 		// inside a list
 		{doc: "x = [os.]", char: 8, expected: []string{"environ", "name"}, osSys: true},
 		// inside a binary expression

--- a/pkg/analysis/signature.go
+++ b/pkg/analysis/signature.go
@@ -10,15 +10,20 @@ import (
 
 func (a *Analyzer) signatureInformation(doc document.Document, node *sitter.Node, fnName string) (protocol.SignatureInformation, bool) {
 	var sig protocol.SignatureInformation
-	for n := node; n != nil; n = n.Parent() {
-		var found bool
+	var found bool
+
+	for n := node; n != nil && !query.IsModuleScope(doc, n); n = n.Parent() {
 		sig, found = query.Function(doc, n, fnName)
 		if found {
 			break
 		}
 	}
 
-	if sig.Label == "" {
+	if !found {
+		sig, found = doc.Functions()[fnName]
+	}
+
+	if !found {
 		sig = a.builtins.Functions[fnName]
 	}
 

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -236,7 +236,7 @@ func loadStatement(input []byte, n *sitter.Node) (LoadStatement, []protocol.Diag
 		return protocol.Diagnostic{
 			Range:    query.NodeRange(nn),
 			Severity: protocol.DiagnosticSeverityError,
-			Message:  fmt.Sprintf("load parameter must be a literal string, found '%s'", nn.Content(input)),
+			Message:  fmt.Sprintf("load parameter must be a string literal, found '%s'", nn.Content(input)),
 		}
 	}
 	args := make([]*sitter.Node, argsNode.NamedChildCount())

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -23,6 +23,13 @@ type Document interface {
 type NewDocumentFunc func(input []byte, tree *sitter.Tree) Document
 
 func NewDocument(input []byte, tree *sitter.Tree) Document {
+	return document{
+		input: input,
+		tree:  tree,
+	}
+}
+
+func NewDocumentWithSymbols(input []byte, tree *sitter.Tree) Document {
 	doc := document{
 		input: input,
 		tree:  tree,

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -14,6 +14,7 @@ type Document interface {
 	Tree() *sitter.Tree
 	Functions() map[string]protocol.SignatureInformation
 	Symbols() []protocol.DocumentSymbol
+	Diagnostics() []protocol.Diagnostic
 
 	Copy() Document
 
@@ -59,8 +60,9 @@ type document struct {
 	// tree represents the parsed version of the document.
 	tree *sitter.Tree
 
-	functions map[string]protocol.SignatureInformation
-	symbols   []protocol.DocumentSymbol
+	functions   map[string]protocol.SignatureInformation
+	symbols     []protocol.DocumentSymbol
+	diagnostics []protocol.Diagnostic
 }
 
 var _ Document = document{}
@@ -83,6 +85,10 @@ func (d document) Functions() map[string]protocol.SignatureInformation {
 
 func (d document) Symbols() []protocol.DocumentSymbol {
 	return d.symbols
+}
+
+func (d document) Diagnostics() []protocol.Diagnostic {
+	return d.diagnostics
 }
 
 func (d document) Close() {

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -149,7 +149,7 @@ func (d *document) Copy() Document {
 
 // Follow (evaulate) the parsed load statements and assign symbols, functions
 // and diagnostics discovered from parsing the dependent document.
-func (d *document) processLoads(ctx context.Context, m *Manager) {
+func (d *document) processLoads(ctx context.Context, m *Manager, parseState DocumentMap) {
 	for i, load := range d.loads {
 		if load.File == "" {
 			continue
@@ -157,7 +157,7 @@ func (d *document) processLoads(ctx context.Context, m *Manager) {
 		path, err := resolvePath(load.File, d.uri)
 		var dep Document
 		if err == nil {
-			dep, err = m.readAndParse(ctx, path)
+			dep, err = m.readAndParse(ctx, path, parseState)
 		}
 		if err != nil {
 			diag := protocol.Diagnostic{

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -22,6 +22,19 @@ func NewDocument(input []byte, tree *sitter.Tree) Document {
 	}
 }
 
+func NodesToContent(doc Document, nodes []*sitter.Node) string {
+	var content string
+	if len(nodes) > 0 {
+		content = doc.ContentRange(sitter.Range{
+			StartByte: nodes[0].StartByte(),
+			EndByte:   nodes[len(nodes)-1].EndByte(),
+		})
+	} else {
+		content = doc.Content(doc.Tree().RootNode())
+	}
+	return content
+}
+
 type document struct {
 	// input is the file as it exists in the editor buffer.
 	input []byte

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -1,6 +1,8 @@
 package document
 
 import (
+	"context"
+
 	sitter "github.com/smacker/go-tree-sitter"
 	"go.lsp.dev/protocol"
 
@@ -110,4 +112,8 @@ func (d document) Copy() Document {
 		doc.functions[fn] = d.functions[fn]
 	}
 	return doc
+}
+
+func (d document) processLoads(ctx context.Context, m *Manager) error {
+	return nil
 }

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -1,12 +1,19 @@
 package document
 
-import sitter "github.com/smacker/go-tree-sitter"
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+	"go.lsp.dev/protocol"
+
+	"github.com/tilt-dev/starlark-lsp/pkg/query"
+)
 
 type Document interface {
 	Content(n *sitter.Node) string
 	ContentRange(r sitter.Range) string
 
 	Tree() *sitter.Tree
+	Functions() map[string]protocol.SignatureInformation
+	Symbols() []protocol.DocumentSymbol
 
 	Copy() Document
 
@@ -16,10 +23,13 @@ type Document interface {
 type NewDocumentFunc func(input []byte, tree *sitter.Tree) Document
 
 func NewDocument(input []byte, tree *sitter.Tree) Document {
-	return document{
+	doc := document{
 		input: input,
 		tree:  tree,
 	}
+	doc.functions = query.Functions(doc, tree.RootNode())
+	doc.symbols = query.DocumentSymbols(doc)
+	return doc
 }
 
 func NodesToContent(doc Document, nodes []*sitter.Node) string {
@@ -41,6 +51,9 @@ type document struct {
 
 	// tree represents the parsed version of the document.
 	tree *sitter.Tree
+
+	functions map[string]protocol.SignatureInformation
+	symbols   []protocol.DocumentSymbol
 }
 
 var _ Document = document{}
@@ -57,6 +70,14 @@ func (d document) Tree() *sitter.Tree {
 	return d.tree
 }
 
+func (d document) Functions() map[string]protocol.SignatureInformation {
+	return d.functions
+}
+
+func (d document) Symbols() []protocol.DocumentSymbol {
+	return d.symbols
+}
+
 func (d document) Close() {
 	d.tree.Close()
 }
@@ -66,8 +87,14 @@ func (d document) Close() {
 // The Contents byte slice is returned as-is.
 // A shallow copy of the Tree is made, as Tree-sitter trees are not thread-safe.
 func (d document) Copy() Document {
-	return document{
-		input: d.input,
-		tree:  d.tree.Copy(),
+	doc := document{
+		input:     d.input,
+		tree:      d.tree.Copy(),
+		functions: make(map[string]protocol.SignatureInformation),
+		symbols:   append([]protocol.DocumentSymbol{}, d.symbols...),
 	}
+	for fn := range d.functions {
+		doc.functions[fn] = d.functions[fn]
+	}
+	return doc
 }

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -40,14 +40,6 @@ type Document interface {
 type NewDocumentFunc func(u uri.URI, input []byte, tree *sitter.Tree) Document
 
 func NewDocument(u uri.URI, input []byte, tree *sitter.Tree) Document {
-	return &document{
-		uri:   u,
-		input: input,
-		tree:  tree,
-	}
-}
-
-func NewDocumentWithSymbols(u uri.URI, input []byte, tree *sitter.Tree) Document {
 	doc := &document{
 		uri:   u,
 		input: input,

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -163,8 +163,20 @@ func (d *document) followLoads(ctx context.Context, m *Manager, parseState Docum
 				Severity: protocol.DiagnosticSeverityError,
 				Message:  err.Error(),
 			}
-			d.loads[i].Diagnostics = append(d.loads[i].Diagnostics, diag)
-			d.diagnostics = append(d.diagnostics, diag)
+
+			// When doc is cached in memory, the diagnostic could have been
+			// added previously. Avoid duplicates.
+			exists := false
+			for _, d := range load.Diagnostics {
+				if diag.Range == d.Range && diag.Message == d.Message {
+					exists = true
+					break
+				}
+			}
+			if !exists {
+				d.loads[i].Diagnostics = append(d.loads[i].Diagnostics, diag)
+				d.diagnostics = append(d.diagnostics, diag)
+			}
 			continue
 		}
 		if !load.processed {

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -59,6 +59,8 @@ func NewDocumentWithSymbols(u uri.URI, input []byte, tree *sitter.Tree) Document
 	return doc
 }
 
+// Returns the source content for the (assumed neighboring) nodes. If slice is
+// nil or empty, return the entire document.
 func NodesToContent(doc Document, nodes []*sitter.Node) string {
 	var content string
 	if len(nodes) > 0 {
@@ -145,6 +147,8 @@ func (d *document) Copy() Document {
 	return doc
 }
 
+// Follow (evaulate) the parsed load statements and assign symbols, functions
+// and diagnostics discovered from parsing the dependent document.
 func (d *document) processLoads(ctx context.Context, m *Manager) {
 	for i, load := range d.loads {
 		if load.File == "" {
@@ -195,6 +199,7 @@ func (d *document) processLoads(ctx context.Context, m *Manager) {
 	}
 }
 
+// Parse (but do not evaluate) load statements in the document.
 func (d *document) parseLoadStatements() {
 	nodes := query.LoadStatements(d.input, d.tree)
 	for _, n := range nodes {

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -167,10 +167,8 @@ func (d *document) processLoads(ctx context.Context, m *Manager) {
 				sym.Name = v[0]
 				sym.Range = load.Range
 				d.symbols = append(d.symbols, sym)
-				if sym.Kind == protocol.SymbolKindFunction {
-					if f, ok := fns[v[1]]; ok {
-						d.functions[v[0]] = f
-					}
+				if f, ok := fns[v[1]]; ok {
+					d.functions[v[0]] = f
 				}
 			} else {
 				d.diagnostics = append(d.diagnostics, protocol.Diagnostic{

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -34,17 +34,19 @@ type Document interface {
 	Close()
 }
 
-type NewDocumentFunc func(input []byte, tree *sitter.Tree) Document
+type NewDocumentFunc func(u uri.URI, input []byte, tree *sitter.Tree) Document
 
-func NewDocument(input []byte, tree *sitter.Tree) Document {
+func NewDocument(u uri.URI, input []byte, tree *sitter.Tree) Document {
 	return &document{
+		uri:   u,
 		input: input,
 		tree:  tree,
 	}
 }
 
-func NewDocumentWithSymbols(input []byte, tree *sitter.Tree) Document {
+func NewDocumentWithSymbols(u uri.URI, input []byte, tree *sitter.Tree) Document {
 	doc := &document{
+		uri:   u,
 		input: input,
 		tree:  tree,
 	}
@@ -68,6 +70,8 @@ func NodesToContent(doc Document, nodes []*sitter.Node) string {
 }
 
 type document struct {
+	uri uri.URI
+
 	// input is the file as it exists in the editor buffer.
 	input []byte
 
@@ -120,6 +124,7 @@ func (d *document) Close() {
 // A shallow copy of the Tree is made, as Tree-sitter trees are not thread-safe.
 func (d *document) Copy() Document {
 	doc := &document{
+		uri:         d.uri,
 		input:       d.input,
 		tree:        d.tree.Copy(),
 		functions:   make(map[string]protocol.SignatureInformation),

--- a/pkg/document/manager.go
+++ b/pkg/document/manager.go
@@ -26,7 +26,7 @@ type Manager struct {
 func NewDocumentManager(opts ...ManagerOpt) *Manager {
 	m := Manager{
 		docs:        make(map[uri.URI]Document),
-		newDocFunc:  NewDocument,
+		newDocFunc:  NewDocumentWithSymbols,
 		readDocFunc: ReadDocument,
 	}
 

--- a/pkg/document/manager.go
+++ b/pkg/document/manager.go
@@ -1,26 +1,33 @@
 package document
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"sync"
 
 	sitter "github.com/smacker/go-tree-sitter"
 	"go.lsp.dev/uri"
+
+	"github.com/tilt-dev/starlark-lsp/pkg/query"
 )
 
 type ManagerOpt func(manager *Manager)
+type ReadDocumentFunc func(uri.URI) ([]byte, error)
 
 // Manager provides simplified file read/write operations for the LSP server.
 type Manager struct {
-	mu         sync.Mutex
-	docs       map[uri.URI]Document
-	newDocFunc NewDocumentFunc
+	mu          sync.Mutex
+	docs        map[uri.URI]Document
+	newDocFunc  NewDocumentFunc
+	readDocFunc ReadDocumentFunc
 }
 
 func NewDocumentManager(opts ...ManagerOpt) *Manager {
 	m := Manager{
-		docs:       make(map[uri.URI]Document),
-		newDocFunc: NewDocument,
+		docs:        make(map[uri.URI]Document),
+		newDocFunc:  NewDocument,
+		readDocFunc: ReadDocument,
 	}
 
 	for _, opt := range opts {
@@ -36,25 +43,56 @@ func WithNewDocumentFunc(newDocFunc NewDocumentFunc) ManagerOpt {
 	}
 }
 
+func ReadDocument(u uri.URI) (contents []byte, err error) {
+	defer func() {
+		// recover from non-file URI in uri.Filename()
+		if r := recover(); r != nil {
+			err = r.(error)
+		}
+	}()
+	return os.ReadFile(u.Filename())
+}
+
 // Read returns the contents of the file for the given URI.
 //
 // If no file exists at the path or the URI is of an invalid type, an error is
 // returned.
-func (m *Manager) Read(uri uri.URI) (Document, error) {
+func (m *Manager) Read(ctx context.Context, uri uri.URI) (Document, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if doc, ok := m.docs[uri]; ok {
 		return doc.Copy(), nil
 	}
-	return nil, os.ErrNotExist
+
+	contents, err := m.readDocFunc(uri)
+	if err == nil {
+		var tree *sitter.Tree
+		tree, err = query.Parse(ctx, contents)
+		if err == nil {
+			doc := m.newDocFunc(contents, tree)
+			m.docs[uri] = doc
+			return doc.Copy(), nil
+		}
+	}
+	if os.IsNotExist(err) {
+		err = os.ErrNotExist
+	}
+
+	return nil, err
 }
 
 // Write creates or replaces the contents of the file for the given URI.
-func (m *Manager) Write(uri uri.URI, input []byte, tree *sitter.Tree) {
+func (m *Manager) Write(ctx context.Context, uri uri.URI, input []byte) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.removeAndCleanup(uri)
+	tree, err := query.Parse(ctx, input)
+	if err != nil {
+		return fmt.Errorf("could not parse file %q: %v", uri, err)
+	}
+
 	m.docs[uri] = m.newDocFunc(input, tree)
+	return nil
 }
 
 func (m *Manager) Remove(uri uri.URI) {

--- a/pkg/document/manager.go
+++ b/pkg/document/manager.go
@@ -178,7 +178,7 @@ func (m *Manager) parse(ctx context.Context, uri uri.URI, input []byte) (doc Doc
 	}
 	tree, err := query.Parse(ctx, input)
 	if err == nil {
-		doc = m.newDocFunc(input, tree)
+		doc = m.newDocFunc(uri, input, tree)
 		m.parseState[uri] = doc
 		if docx, ok := doc.(*document); ok {
 			docx.processLoads(ctx, m)

--- a/pkg/document/manager.go
+++ b/pkg/document/manager.go
@@ -29,7 +29,7 @@ type Manager struct {
 func NewDocumentManager(opts ...ManagerOpt) *Manager {
 	m := Manager{
 		docs:        make(DocumentMap),
-		newDocFunc:  NewDocumentWithSymbols,
+		newDocFunc:  NewDocument,
 		readDocFunc: ReadDocument,
 	}
 

--- a/pkg/document/manager.go
+++ b/pkg/document/manager.go
@@ -180,8 +180,8 @@ func (m *Manager) parse(ctx context.Context, uri uri.URI, input []byte) (doc Doc
 	if err == nil {
 		doc = m.newDocFunc(input, tree)
 		m.parseState[uri] = doc
-		if docx, ok := doc.(document); ok {
-			err = docx.processLoads(ctx, m)
+		if docx, ok := doc.(*document); ok {
+			docx.processLoads(ctx, m)
 		}
 	}
 	return doc, err

--- a/pkg/document/manager.go
+++ b/pkg/document/manager.go
@@ -61,6 +61,7 @@ func (m *Manager) Read(ctx context.Context, uri uri.URI) (Document, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if doc, ok := m.docs[uri]; ok {
+		// TODO(siegs): check staleness for files read from disk?
 		return doc.Copy(), nil
 	}
 

--- a/pkg/document/manager_test.go
+++ b/pkg/document/manager_test.go
@@ -1,0 +1,40 @@
+package document
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/uri"
+)
+
+func TestManagerRead(t *testing.T) {
+	f := newFixture(t)
+	_, err := f.m.Read(f.ctx, uri.File("doesnotexist"))
+	require.ErrorIs(t, os.ErrNotExist, err)
+	_, err = f.m.Read(f.ctx, uri.URI("https://example.com/"))
+	require.EqualError(t, err, "only file URIs are supported, got https")
+	_ = os.WriteFile("doc", []byte(""), 0644)
+	doc, err := f.m.Read(f.ctx, uri.File("doc"))
+	require.NoError(t, err)
+	assert.Equal(t, "", doc.Content(doc.Tree().RootNode()))
+}
+
+type fixture struct {
+	ctx context.Context
+	m   *Manager
+}
+
+func newFixture(t *testing.T) *fixture {
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+	dir := t.TempDir()
+	require.NoError(t, os.Chdir(dir))
+	return &fixture{
+		ctx: context.Background(),
+		m:   NewDocumentManager(),
+	}
+}

--- a/pkg/document/manager_test.go
+++ b/pkg/document/manager_test.go
@@ -34,7 +34,9 @@ func TestReadWithLoad(t *testing.T) {
 	assert.Equal(t, 0, len(doc.Diagnostics()))
 	syms := doc.Symbols()
 	assert.Equal(t, 1, len(syms))
-	//assert.Equal(t, "foo", syms[0].Name)
+	if len(syms) == 1 {
+		assert.Equal(t, "foo", syms[0].Name)
+	}
 }
 
 func TestNestedLoad(t *testing.T) {

--- a/pkg/query/conv.go
+++ b/pkg/query/conv.go
@@ -1,6 +1,7 @@
 package query
 
 import (
+	"fmt"
 	"strconv"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -10,7 +11,8 @@ import (
 // Unquote a Tree sitter string node into its string contents.
 //
 // Also accepts a parent module, block or expression statement containing a
-// string node for convenience.
+// string node for convenience. If a non-string node is passed, Unquote will
+// panic().
 //
 // Tree sitter parses a string literal into 2 or more child nodes
 // representing the beginning/ending delimiters, and any number of escape
@@ -43,7 +45,7 @@ done:
 		case NodeTypeString:
 			break done
 		default:
-			return ""
+			panic(fmt.Errorf("[Unquote:bug:unexpected node: %s: %s]", n.Type(), n.Content(input)))
 		}
 	}
 

--- a/pkg/query/conv.go
+++ b/pkg/query/conv.go
@@ -1,9 +1,55 @@
 package query
 
 import (
+	"strconv"
+
 	sitter "github.com/smacker/go-tree-sitter"
 	"go.lsp.dev/protocol"
 )
+
+func Unquote(input []byte, n *sitter.Node) string {
+done:
+	for {
+		switch n.Type() {
+		case NodeTypeModule,
+			NodeTypeBlock,
+			NodeTypeExpressionStatement:
+			n = n.Child(0)
+		case NodeTypeString:
+			break done
+		default:
+			return ""
+		}
+	}
+
+	startDelim := n.Child(0)
+	endDelim := n.Child(int(n.ChildCount() - 1))
+	byteoffset := startDelim.EndByte()
+	bytes := []byte{}
+
+	for i := 1; i < int(n.ChildCount()-1); i++ {
+		escape := n.Child(i)
+		if byteoffset < escape.StartByte() {
+			bytes = append(bytes, input[byteoffset:escape.StartByte()]...)
+			byteoffset = escape.EndByte()
+		}
+		escseq := string(input[escape.StartByte():escape.EndByte()])
+		if escseq == "\\\n" {
+			// ignore backslash at the end of a line per Starlark spec
+			escseq = "\n"
+		} else {
+			// use Go Unquote to expand the escape sequence
+			escseq, _ = strconv.Unquote(`"` + escseq + `"`)
+		}
+		bytes = append(bytes, []byte(escseq)...)
+	}
+
+	if byteoffset < endDelim.StartByte() {
+		bytes = append(bytes, input[byteoffset:endDelim.StartByte()]...)
+	}
+
+	return string(bytes)
+}
 
 func nodeTypeToSymbolKind(n *sitter.Node) protocol.SymbolKind {
 	switch n.Type() {

--- a/pkg/query/conv.go
+++ b/pkg/query/conv.go
@@ -7,6 +7,31 @@ import (
 	"go.lsp.dev/protocol"
 )
 
+// Unquote a Tree sitter string node into its string contents.
+//
+// Also accepts a parent module, block or expression statement containing a
+// string node for convenience.
+//
+// Tree sitter parses a string literal into 2 or more child nodes
+// representing the beginning/ending delimiters, and any number of escape
+// sequences inside. Thus, the string
+//
+//    """hello\nTilted\nWorld"""
+//
+// gets parsed into a tree like:
+//
+//   module [0, 0] - [1, 0]
+//     expression_statement [0, 0] - [0, 26]
+//       string [0, 0] - [0, 26]
+//         " [0, 0] - [0, 3]
+//         escape_sequence [0, 8] - [0, 10]
+//         escape_sequence [0, 16] - [0, 18]
+//         " [0, 23] - [0, 26]
+//
+// Notably, there are no nodes to represent the contents in between the string
+// delimiters and any escape sequences, so we have to extract those manually
+// based on the start/end byte boundaries of the adjacent delimiter or escape
+// sequence nodes.
 func Unquote(input []byte, n *sitter.Node) string {
 done:
 	for {
@@ -31,17 +56,18 @@ done:
 		escape := n.Child(i)
 		if byteoffset < escape.StartByte() {
 			bytes = append(bytes, input[byteoffset:escape.StartByte()]...)
-			byteoffset = escape.EndByte()
 		}
-		escseq := string(input[escape.StartByte():escape.EndByte()])
+		escseq := string(escape.Content(input))
 		if escseq == "\\\n" {
-			// ignore backslash-newline line continuation at the end of a line per Starlark spec
+			// ignore backslash-newline line continuation at the end of a line
+			// per Starlark spec
 			escseq = ""
 		} else {
 			// use Go Unquote to expand the escape sequence
 			escseq, _ = strconv.Unquote(`"` + escseq + `"`)
 		}
 		bytes = append(bytes, []byte(escseq)...)
+		byteoffset = escape.EndByte()
 	}
 
 	if byteoffset < endDelim.StartByte() {

--- a/pkg/query/conv.go
+++ b/pkg/query/conv.go
@@ -35,8 +35,8 @@ done:
 		}
 		escseq := string(input[escape.StartByte():escape.EndByte()])
 		if escseq == "\\\n" {
-			// ignore backslash at the end of a line per Starlark spec
-			escseq = "\n"
+			// ignore backslash-newline line continuation at the end of a line per Starlark spec
+			escseq = ""
 		} else {
 			// use Go Unquote to expand the escape sequence
 			escseq, _ = strconv.Unquote(`"` + escseq + `"`)

--- a/pkg/query/conv_test.go
+++ b/pkg/query/conv_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestUnquote(t *testing.T) {
 	cases := [][2]string{
-		{`hello`, ""},
 		{`"hello"`, "hello"},
 		{`r"hello"`, "hello"},
 		{`r"he\nllo"`, "he\\nllo"},
@@ -39,9 +38,18 @@ world"`, "helloworld"},
 	for i, tt := range cases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			q := newQueryFixture(t, nil, tt[0])
-			n := q.root.NamedChild(0)
-			v := query.Unquote(q.input, n)
+			v := query.Unquote(q.input, q.root)
 			assert.Equal(t, tt[1], v)
 		})
 	}
+}
+
+func TestUnquotePanic(t *testing.T) {
+	q := newQueryFixture(t, nil, `hello`)
+	defer func() {
+		e := recover().(error)
+		assert.NotNil(t, e)
+		assert.Equal(t, "[Unquote:bug:unexpected node: identifier: hello]", e.Error())
+	}()
+	query.Unquote(q.input, q.root)
 }

--- a/pkg/query/conv_test.go
+++ b/pkg/query/conv_test.go
@@ -1,0 +1,44 @@
+package query_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/tilt-dev/starlark-lsp/pkg/query"
+)
+
+func TestUnquote(t *testing.T) {
+	cases := [][2]string{
+		{`hello`, ""},
+		{`"hello"`, "hello"},
+		{`r"hello"`, "hello"},
+		{`r"he\nllo"`, "he\\nllo"},
+		{`b"hello"`, "hello"},
+		{`rb"hello"`, "hello"},
+		{`"""hello"""`, "hello"},
+		{`'''hello'''`, "hello"},
+		{`r'''hello'''`, "hello"},
+		{`b'''hello'''`, "hello"},
+		{`"he\nllo"`, "he\nllo"},
+		{`"he\"llo"`, "he\"llo"},
+		{`"he\rllo"`, "he\rllo"},
+		{`"he\tllo"`, "he\tllo"},
+		{`"he\\llo"`, "he\\llo"},
+		{`"he\nll\no"`, "he\nll\no"},
+		{`"he\u0034llo"`, "he\u0034llo"},
+		{`"he\x32llo"`, "he\x32llo"},
+		{`"he\001llo"`, "he\001llo"},
+		{`"hello\
+world"`, "hello\nworld"},
+	}
+	for i, tt := range cases {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			q := newQueryFixture(t, nil, tt[0])
+			n := q.root.NamedChild(0)
+			v := query.Unquote(q.input, n)
+			assert.Equal(t, tt[1], v)
+		})
+	}
+}

--- a/pkg/query/conv_test.go
+++ b/pkg/query/conv_test.go
@@ -32,6 +32,9 @@ func TestUnquote(t *testing.T) {
 		{`"he\001llo"`, "he\001llo"},
 		{`"hello\
 world"`, "helloworld"},
+		{`"hello\n\n"`, "hello\n\n"},
+		{`"\n\t\v\b"`, "\n\t\v\b"},
+		{`""`, ""},
 	}
 	for i, tt := range cases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {

--- a/pkg/query/conv_test.go
+++ b/pkg/query/conv_test.go
@@ -31,7 +31,7 @@ func TestUnquote(t *testing.T) {
 		{`"he\x32llo"`, "he\x32llo"},
 		{`"he\001llo"`, "he\001llo"},
 		{`"hello\
-world"`, "hello\nworld"},
+world"`, "helloworld"},
 	}
 	for i, tt := range cases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {

--- a/pkg/query/document_content.go
+++ b/pkg/query/document_content.go
@@ -5,6 +5,7 @@ import (
 )
 
 type DocumentContent interface {
+	Input() []byte
 	Content(n *sitter.Node) string
 	ContentRange(r sitter.Range) string
 	Tree() *sitter.Tree

--- a/pkg/query/document_content.go
+++ b/pkg/query/document_content.go
@@ -1,0 +1,11 @@
+package query
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+type DocumentContent interface {
+	Content(n *sitter.Node) string
+	ContentRange(r sitter.Range) string
+	Tree() *sitter.Tree
+}

--- a/pkg/query/identifiers.go
+++ b/pkg/query/identifiers.go
@@ -2,11 +2,9 @@ package query
 
 import (
 	sitter "github.com/smacker/go-tree-sitter"
-
-	"github.com/tilt-dev/starlark-lsp/pkg/document"
 )
 
-func ExtractIdentifiers(doc document.Document, nodes []*sitter.Node, limit *sitter.Point) []string {
+func ExtractIdentifiers(doc DocumentContent, nodes []*sitter.Node, limit *sitter.Point) []string {
 	identifiers := []string{}
 
 	for i, node := range nodes {

--- a/pkg/query/identifiers_test.go
+++ b/pkg/query/identifiers_test.go
@@ -46,7 +46,7 @@ print("")`, expected: []string{"os", "path", ""}, limit: &sitter.Point{Column: 8
 	for _, tt := range tests {
 		t.Run(tt.doc, func(t *testing.T) {
 			f := newQueryFixture(t, []byte{}, tt.doc)
-			doc := document.NewDocument(f.input, f.tree)
+			doc := document.NewDocument("", f.input, f.tree)
 			ids := query.ExtractIdentifiers(doc, []*sitter.Node{f.tree.RootNode()}, tt.limit)
 			assert.ElementsMatch(t, tt.expected, ids)
 		})

--- a/pkg/query/location.go
+++ b/pkg/query/location.go
@@ -3,8 +3,6 @@ package query
 import (
 	sitter "github.com/smacker/go-tree-sitter"
 	"go.lsp.dev/protocol"
-
-	"github.com/tilt-dev/starlark-lsp/pkg/document"
 )
 
 // PositionToPoint converts an LSP protocol file location to a Tree-sitter file location.
@@ -79,11 +77,11 @@ func NodeBefore(a, b *sitter.Node) bool {
 }
 
 // NamedNodeAtPosition returns the most granular named descendant at a position.
-func NamedNodeAtPosition(doc document.Document, pos protocol.Position) (*sitter.Node, bool) {
+func NamedNodeAtPosition(doc DocumentContent, pos protocol.Position) (*sitter.Node, bool) {
 	return NamedNodeAtPoint(doc, PositionToPoint(pos))
 }
 
-func NamedNodeAtPoint(doc document.Document, pt sitter.Point) (*sitter.Node, bool) {
+func NamedNodeAtPoint(doc DocumentContent, pt sitter.Point) (*sitter.Node, bool) {
 	if doc.Tree() == nil {
 		return nil, false
 	}
@@ -94,12 +92,12 @@ func NamedNodeAtPoint(doc document.Document, pt sitter.Point) (*sitter.Node, boo
 	return nil, false
 }
 
-func ChildNodeAtPoint(doc document.Document, pt sitter.Point, node *sitter.Node) (*sitter.Node, bool) {
+func ChildNodeAtPoint(pt sitter.Point, node *sitter.Node) (*sitter.Node, bool) {
 	count := int(node.NamedChildCount())
 	for i := 0; i < count; i++ {
 		child := node.NamedChild(i)
 		if PointBeforeOrEqual(child.StartPoint(), pt) && PointBeforeOrEqual(pt, child.EndPoint()) {
-			return ChildNodeAtPoint(doc, pt, child)
+			return ChildNodeAtPoint(pt, child)
 		}
 	}
 	return node, true
@@ -107,14 +105,14 @@ func ChildNodeAtPoint(doc document.Document, pt sitter.Point, node *sitter.Node)
 
 // NodeAtPosition returns the node (named or unnamed) with the smallest
 // start/end range that covers the given position.
-func NodeAtPosition(doc document.Document, pos protocol.Position) (*sitter.Node, bool) {
+func NodeAtPosition(doc DocumentContent, pos protocol.Position) (*sitter.Node, bool) {
 	return NodeAtPoint(doc, PositionToPoint(pos))
 }
 
-func NodeAtPoint(doc document.Document, pt sitter.Point) (*sitter.Node, bool) {
+func NodeAtPoint(doc DocumentContent, pt sitter.Point) (*sitter.Node, bool) {
 	namedNode, ok := NamedNodeAtPoint(doc, pt)
 	if !ok {
 		return nil, false
 	}
-	return ChildNodeAtPoint(doc, pt, namedNode)
+	return ChildNodeAtPoint(pt, namedNode)
 }

--- a/pkg/query/params.go
+++ b/pkg/query/params.go
@@ -8,7 +8,6 @@ import (
 	sitter "github.com/smacker/go-tree-sitter"
 
 	"github.com/tilt-dev/starlark-lsp/pkg/docstring"
-	"github.com/tilt-dev/starlark-lsp/pkg/document"
 )
 
 type parameter struct {
@@ -46,7 +45,7 @@ func (p parameter) paramInfo(fnDocs docstring.Parsed) protocol.ParameterInformat
 	return pi
 }
 
-func extractParameters(doc document.Document, fnDocs docstring.Parsed,
+func extractParameters(doc DocumentContent, fnDocs docstring.Parsed,
 	node *sitter.Node) []protocol.ParameterInformation {
 	if node.Type() != NodeTypeParameters {
 		// A query is used here because there's several different node types

--- a/pkg/query/queries.go
+++ b/pkg/query/queries.go
@@ -35,3 +35,18 @@ func LeafNodes(node *sitter.Node) []*sitter.Node {
 	})
 	return nodes
 }
+
+func LoadStatements(input []byte, tree *sitter.Tree) []*sitter.Node {
+	nodes := []*sitter.Node{}
+	Query(tree.RootNode(), []byte(`(expression_statement (call) @call)`), func(q *sitter.Query, match *sitter.QueryMatch) bool {
+		for _, c := range match.Captures {
+			id := c.Node.ChildByFieldName("function")
+			name := id.Content(input)
+			if name == "load" {
+				nodes = append(nodes, c.Node)
+			}
+		}
+		return true
+	})
+	return nodes
+}

--- a/pkg/query/queries.go
+++ b/pkg/query/queries.go
@@ -38,7 +38,7 @@ func LeafNodes(node *sitter.Node) []*sitter.Node {
 
 func LoadStatements(input []byte, tree *sitter.Tree) []*sitter.Node {
 	nodes := []*sitter.Node{}
-	Query(tree.RootNode(), []byte(`(expression_statement (call) @call)`), func(q *sitter.Query, match *sitter.QueryMatch) bool {
+	Query(tree.RootNode(), []byte(`(call) @call`), func(q *sitter.Query, match *sitter.QueryMatch) bool {
 		for _, c := range match.Captures {
 			id := c.Node.ChildByFieldName("function")
 			name := id.Content(input)

--- a/pkg/query/signature.go
+++ b/pkg/query/signature.go
@@ -9,11 +9,10 @@ import (
 	sitter "github.com/smacker/go-tree-sitter"
 
 	"github.com/tilt-dev/starlark-lsp/pkg/docstring"
-	"github.com/tilt-dev/starlark-lsp/pkg/document"
 )
 
 // Functions finds all function definitions that are direct children of the provided sitter.Node.
-func Functions(doc document.Document, node *sitter.Node) map[string]protocol.SignatureInformation {
+func Functions(doc DocumentContent, node *sitter.Node) map[string]protocol.SignatureInformation {
 	signatures := make(map[string]protocol.SignatureInformation)
 
 	// N.B. we don't use a query here for a couple reasons:
@@ -36,7 +35,7 @@ func Functions(doc document.Document, node *sitter.Node) map[string]protocol.Sig
 }
 
 // Function finds a function definition for the given function name that is a direct child of the provided sitter.Node.
-func Function(doc document.Document, node *sitter.Node, fnName string) (protocol.SignatureInformation, bool) {
+func Function(doc DocumentContent, node *sitter.Node, fnName string) (protocol.SignatureInformation, bool) {
 	for n := node.NamedChild(0); n != nil; n = n.NextNamedSibling() {
 		if n.Type() != NodeTypeFunctionDef {
 			continue
@@ -50,7 +49,7 @@ func Function(doc document.Document, node *sitter.Node, fnName string) (protocol
 	return protocol.SignatureInformation{}, false
 }
 
-func extractSignatureInformation(doc document.Document, n *sitter.Node) (string, protocol.SignatureInformation) {
+func extractSignatureInformation(doc DocumentContent, n *sitter.Node) (string, protocol.SignatureInformation) {
 	if n.Type() != NodeTypeFunctionDef {
 		panic(fmt.Errorf("invalid node type: %s", n.Type()))
 	}
@@ -102,7 +101,7 @@ func signatureLabel(params []protocol.ParameterInformation, returnType string) s
 	return sb.String()
 }
 
-func extractDocstring(doc document.Document, n *sitter.Node) docstring.Parsed {
+func extractDocstring(doc DocumentContent, n *sitter.Node) docstring.Parsed {
 	if n.Type() != NodeTypeBlock {
 		panic(fmt.Errorf("invalid node type: %s", n.Type()))
 	}

--- a/pkg/query/signature.go
+++ b/pkg/query/signature.go
@@ -108,15 +108,7 @@ func extractDocstring(doc DocumentContent, n *sitter.Node) docstring.Parsed {
 
 	if exprNode := n.NamedChild(0); exprNode != nil && exprNode.Type() == NodeTypeExpressionStatement {
 		if docStringNode := exprNode.NamedChild(0); docStringNode != nil && docStringNode.Type() == NodeTypeString {
-			// TODO(milas): need to do nested quote un-escaping (generally
-			// 	docstrings use triple-quoted strings so this isn't a huge
-			// 	issue at least)
-			rawDocString := doc.Content(docStringNode)
-			// this is the raw source, so it will be wrapped with with """ / ''' / " / '
-			// (technically this could trim off too much but not worth the
-			// headache to deal with valid leading/trailing quotes)
-			rawDocString = strings.Trim(rawDocString, `"'`)
-			return docstring.Parse(rawDocString)
+			return docstring.Parse(Unquote(doc.Input(), docStringNode))
 		}
 	}
 

--- a/pkg/query/symbol.go
+++ b/pkg/query/symbol.go
@@ -22,13 +22,14 @@ func SiblingSymbols(doc DocumentContent, node, before *sitter.Node) []protocol.D
 			}
 			symbol.Name = doc.Content(assignment.ChildByFieldName("left"))
 			val := assignment.ChildByFieldName("right")
+			var kind protocol.SymbolKind
 			if val == nil {
 				// python variable assignment without an initial value
-				// (https://peps.python.org/pep-0526/); this is not legal
-				// starlark so skip
-				continue
+				// (https://peps.python.org/pep-0526/); just assume a variable
+				kind = 0
+			} else {
+				kind = nodeTypeToSymbolKind(val)
 			}
-			kind := nodeTypeToSymbolKind(val)
 			if kind == 0 {
 				kind = protocol.SymbolKindVariable
 			}

--- a/pkg/query/symbol.go
+++ b/pkg/query/symbol.go
@@ -21,7 +21,14 @@ func SiblingSymbols(doc DocumentContent, node, before *sitter.Node) []protocol.D
 				continue
 			}
 			symbol.Name = doc.Content(assignment.ChildByFieldName("left"))
-			kind := nodeTypeToSymbolKind(assignment.ChildByFieldName("right"))
+			val := assignment.ChildByFieldName("right")
+			if val == nil {
+				// python variable assignment without an initial value
+				// (https://peps.python.org/pep-0526/); this is not legal
+				// starlark so skip
+				continue
+			}
+			kind := nodeTypeToSymbolKind(val)
 			if kind == 0 {
 				kind = protocol.SymbolKindVariable
 			}

--- a/pkg/query/symbol.go
+++ b/pkg/query/symbol.go
@@ -6,13 +6,11 @@ import (
 	"go.lsp.dev/protocol"
 
 	sitter "github.com/smacker/go-tree-sitter"
-
-	"github.com/tilt-dev/starlark-lsp/pkg/document"
 )
 
 // Get all symbols defined at the same level as the given node.
 // If before != nil, only include symbols that appear before that node.
-func SiblingSymbols(doc document.Document, node, before *sitter.Node) []protocol.DocumentSymbol {
+func SiblingSymbols(doc DocumentContent, node, before *sitter.Node) []protocol.DocumentSymbol {
 	var symbols []protocol.DocumentSymbol
 	for n := node; n != nil && NodeBefore(n, before); n = n.NextNamedSibling() {
 		var symbol protocol.DocumentSymbol
@@ -53,7 +51,7 @@ func SiblingSymbols(doc document.Document, node, before *sitter.Node) []protocol
 }
 
 // Get all symbols defined in scopes at or above the level of the given node.
-func SymbolsInScope(doc document.Document, node *sitter.Node) []protocol.DocumentSymbol {
+func SymbolsInScope(doc DocumentContent, node *sitter.Node) []protocol.DocumentSymbol {
 	var symbols []protocol.DocumentSymbol
 	// While we are in the current scope, only include symbols defined before
 	// the provided node.
@@ -72,6 +70,6 @@ func SymbolsInScope(doc document.Document, node *sitter.Node) []protocol.Documen
 }
 
 // DocumentSymbols returns all symbols with document-wide visibility.
-func DocumentSymbols(doc document.Document) []protocol.DocumentSymbol {
+func DocumentSymbols(doc DocumentContent) []protocol.DocumentSymbol {
 	return SiblingSymbols(doc, doc.Tree().RootNode().NamedChild(0), nil)
 }

--- a/pkg/query/symbol_test.go
+++ b/pkg/query/symbol_test.go
@@ -71,7 +71,7 @@ def start():
 	for i, sym := range symbols {
 		names[i] = sym.Name
 	}
-	assert.Equal(t, []string{"bar", "baz", "foo", "start"}, names)
+	assert.Equal(t, []string{"bar", "baz"}, names)
 }
 
 func TestSymbolsInScopeExcludesFollowingSiblings(t *testing.T) {
@@ -96,5 +96,5 @@ def start():
 	for i, sym := range symbols {
 		names[i] = sym.Name
 	}
-	assert.Equal(t, []string{"bar", "baz", "foo", "start"}, names)
+	assert.Equal(t, []string{"bar", "baz"}, names)
 }

--- a/pkg/query/symbol_test.go
+++ b/pkg/query/symbol_test.go
@@ -17,7 +17,7 @@ y = None
 z = True
 `)
 
-	doc := document.NewDocument(f.input, f.tree)
+	doc := document.NewDocument("", f.input, f.tree)
 	symbols := query.DocumentSymbols(doc)
 	names := make([]string, len(symbols))
 	for i, sym := range symbols {
@@ -39,7 +39,7 @@ def start():
   pass
 `)
 
-	doc := document.NewDocument(f.input, f.tree)
+	doc := document.NewDocument("", f.input, f.tree)
 	n, ok := query.NamedNodeAtPosition(doc, protocol.Position{Line: 5, Character: 2})
 	assert.True(t, ok)
 	symbols := query.SiblingSymbols(doc, n.Parent().NamedChild(0), nil)
@@ -63,7 +63,7 @@ def start():
   pass
 `)
 
-	doc := document.NewDocument(f.input, f.tree)
+	doc := document.NewDocument("", f.input, f.tree)
 	n, ok := query.NamedNodeAtPosition(doc, protocol.Position{Line: 5, Character: 2})
 	assert.True(t, ok)
 	symbols := query.SymbolsInScope(doc, n)
@@ -88,7 +88,7 @@ def start():
   pass
 `)
 
-	doc := document.NewDocument(f.input, f.tree)
+	doc := document.NewDocument("", f.input, f.tree)
 	n, ok := query.NamedNodeAtPosition(doc, protocol.Position{Line: 5, Character: 2})
 	assert.True(t, ok)
 	symbols := query.SymbolsInScope(doc, n)

--- a/pkg/server/completion.go
+++ b/pkg/server/completion.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (s *Server) Completion(ctx context.Context, params *protocol.CompletionParams) (*protocol.CompletionList, error) {
-	doc, err := s.docs.Read(params.TextDocument.URI)
+	doc, err := s.docs.Read(ctx, params.TextDocument.URI)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/fixture_test.go
+++ b/pkg/server/fixture_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/tilt-dev/starlark-lsp/pkg/analysis"
 	"github.com/tilt-dev/starlark-lsp/pkg/document"
 	"github.com/tilt-dev/starlark-lsp/pkg/middleware"
-	"github.com/tilt-dev/starlark-lsp/pkg/query"
 	"github.com/tilt-dev/starlark-lsp/pkg/server"
 )
 
@@ -113,14 +112,17 @@ func newFixture(t testing.TB) *fixture {
 func (f *fixture) mustWriteDocument(path string, source string) {
 	f.t.Helper()
 	contents := []byte(source)
-	tree, err := query.Parse(f.ctx, contents)
-	require.NoErrorf(f.t, err, "Failed to parse document %q", path)
-	f.docManager.Write(uri.File(path), contents, tree)
+	require.NoErrorf(
+		f.t,
+		f.docManager.Write(f.ctx, uri.File(path), contents),
+		"Failed to parse document %q",
+		path,
+	)
 }
 
 func (f *fixture) requireDocContents(path string, input string) {
 	f.t.Helper()
-	doc, err := f.docManager.Read(uri.File(path))
+	doc, err := f.docManager.Read(f.ctx, uri.File(path))
 	require.NoErrorf(f.t, err, "Failed to read document %q", path)
 	defer doc.Close()
 	require.NotNil(f.t, doc.Tree(), "Document tree was nil")

--- a/pkg/server/fixture_test.go
+++ b/pkg/server/fixture_test.go
@@ -248,6 +248,10 @@ type testDocument struct {
 
 var _ document.Document = &testDocument{}
 
+func (t *testDocument) Input() []byte {
+	return t.doc.Input()
+}
+
 func (t *testDocument) Content(n *sitter.Node) string {
 	return t.doc.Content(n)
 }

--- a/pkg/server/fixture_test.go
+++ b/pkg/server/fixture_test.go
@@ -189,7 +189,7 @@ func newDocumentManager(t testing.TB) *document.Manager {
 
 	newDocFunc := func(u uri.URI, input []byte, tree *sitter.Tree) document.Document {
 		testDoc := &testDocument{
-			doc:     document.NewDocumentWithSymbols(u, input, tree),
+			doc:     document.NewDocument(u, input, tree),
 			onCopy:  copyFunc,
 			onClose: closeFunc,
 		}

--- a/pkg/server/fixture_test.go
+++ b/pkg/server/fixture_test.go
@@ -188,7 +188,7 @@ func newDocumentManager(t testing.TB) *document.Manager {
 
 	newDocFunc := func(input []byte, tree *sitter.Tree) document.Document {
 		testDoc := &testDocument{
-			doc:     document.NewDocument(input, tree),
+			doc:     document.NewDocumentWithSymbols(input, tree),
 			onCopy:  copyFunc,
 			onClose: closeFunc,
 		}

--- a/pkg/server/fixture_test.go
+++ b/pkg/server/fixture_test.go
@@ -187,9 +187,9 @@ func newDocumentManager(t testing.TB) *document.Manager {
 		delete(openDocs, testDoc)
 	}
 
-	newDocFunc := func(input []byte, tree *sitter.Tree) document.Document {
+	newDocFunc := func(u uri.URI, input []byte, tree *sitter.Tree) document.Document {
 		testDoc := &testDocument{
-			doc:     document.NewDocumentWithSymbols(input, tree),
+			doc:     document.NewDocumentWithSymbols(u, input, tree),
 			onCopy:  copyFunc,
 			onClose: closeFunc,
 		}

--- a/pkg/server/fixture_test.go
+++ b/pkg/server/fixture_test.go
@@ -112,9 +112,10 @@ func newFixture(t testing.TB) *fixture {
 func (f *fixture) mustWriteDocument(path string, source string) {
 	f.t.Helper()
 	contents := []byte(source)
+	_, err := f.docManager.Write(f.ctx, uri.File(path), contents)
 	require.NoErrorf(
 		f.t,
-		f.docManager.Write(f.ctx, uri.File(path), contents),
+		err,
 		"Failed to parse document %q",
 		path,
 	)
@@ -265,6 +266,10 @@ func (t *testDocument) Functions() map[string]protocol.SignatureInformation {
 
 func (t *testDocument) Symbols() []protocol.DocumentSymbol {
 	return t.doc.Symbols()
+}
+
+func (t *testDocument) Diagnostics() []protocol.Diagnostic {
+	return t.doc.Diagnostics()
 }
 
 func (t *testDocument) Copy() document.Document {

--- a/pkg/server/fixture_test.go
+++ b/pkg/server/fixture_test.go
@@ -272,6 +272,10 @@ func (t *testDocument) Diagnostics() []protocol.Diagnostic {
 	return t.doc.Diagnostics()
 }
 
+func (t *testDocument) Loads() []document.LoadStatement {
+	return t.doc.Loads()
+}
+
 func (t *testDocument) Copy() document.Document {
 	copiedDoc := &testDocument{
 		doc:     t.doc.Copy(),

--- a/pkg/server/fixture_test.go
+++ b/pkg/server/fixture_test.go
@@ -259,6 +259,14 @@ func (t *testDocument) Tree() *sitter.Tree {
 	return t.doc.Tree()
 }
 
+func (t *testDocument) Functions() map[string]protocol.SignatureInformation {
+	return t.doc.Functions()
+}
+
+func (t *testDocument) Symbols() []protocol.DocumentSymbol {
+	return t.doc.Symbols()
+}
+
 func (t *testDocument) Copy() document.Document {
 	copiedDoc := &testDocument{
 		doc:     t.doc.Copy(),

--- a/pkg/server/hover.go
+++ b/pkg/server/hover.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (s *Server) Hover(ctx context.Context, params *protocol.HoverParams) (result *protocol.Hover, err error) {
-	doc, err := s.docs.Read(params.TextDocument.URI)
+	doc, err := s.docs.Read(ctx, params.TextDocument.URI)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/initialize.go
+++ b/pkg/server/initialize.go
@@ -7,12 +7,13 @@ import (
 )
 
 func (s *Server) Initialize(ctx context.Context,
-	_ *protocol.InitializeParams) (result *protocol.InitializeResult, err error) {
+	params *protocol.InitializeParams) (result *protocol.InitializeResult, err error) {
 	_ = s.notifier.LogMessage(ctx, &protocol.LogMessageParams{
 		Message: "Starlark LSP server initialized",
 		Type:    protocol.MessageTypeLog,
 	})
 
+	s.docs.Initialize(params)
 	return &protocol.InitializeResult{
 		Capabilities: protocol.ServerCapabilities{
 			TextDocumentSync: protocol.TextDocumentSyncOptions{

--- a/pkg/server/signature.go
+++ b/pkg/server/signature.go
@@ -12,7 +12,7 @@ func (s *Server) SignatureHelp(ctx context.Context,
 	logger := protocol.LoggerFromContext(ctx).
 		With(textDocumentFields(params.TextDocumentPositionParams)...)
 
-	doc, err := s.docs.Read(params.TextDocument.URI)
+	doc, err := s.docs.Read(ctx, params.TextDocument.URI)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/symbol.go
+++ b/pkg/server/symbol.go
@@ -11,7 +11,7 @@ import (
 func (s *Server) DocumentSymbol(ctx context.Context,
 	params *protocol.DocumentSymbolParams) ([]interface{}, error) {
 
-	doc, err := s.docs.Read(params.TextDocument.URI)
+	doc, err := s.docs.Read(ctx, params.TextDocument.URI)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/symbol.go
+++ b/pkg/server/symbol.go
@@ -4,8 +4,6 @@ import (
 	"context"
 
 	"go.lsp.dev/protocol"
-
-	"github.com/tilt-dev/starlark-lsp/pkg/query"
 )
 
 func (s *Server) DocumentSymbol(ctx context.Context,
@@ -17,7 +15,7 @@ func (s *Server) DocumentSymbol(ctx context.Context,
 	}
 	defer doc.Close()
 
-	symbols := query.DocumentSymbols(doc)
+	symbols := doc.Symbols()
 	result := make([]interface{}, len(symbols))
 	for i := range symbols {
 		result[i] = symbols[i]

--- a/pkg/server/text_document_sync.go
+++ b/pkg/server/text_document_sync.go
@@ -2,23 +2,14 @@ package server
 
 import (
 	"context"
-	"fmt"
 
 	"go.lsp.dev/protocol"
-
-	"github.com/tilt-dev/starlark-lsp/pkg/query"
 )
 
 func (s *Server) DidOpen(ctx context.Context, params *protocol.DidOpenTextDocumentParams) (err error) {
 	uri := params.TextDocument.URI
 	contents := []byte(params.TextDocument.Text)
-	tree, err := query.Parse(ctx, contents)
-	if err != nil {
-		return fmt.Errorf("could not parse file %q: %v", uri, err)
-	}
-
-	s.docs.Write(uri, contents, tree)
-	return nil
+	return s.docs.Write(ctx, uri, contents)
 }
 
 func (s *Server) DidChange(ctx context.Context, params *protocol.DidChangeTextDocumentParams) (err error) {
@@ -28,26 +19,13 @@ func (s *Server) DidChange(ctx context.Context, params *protocol.DidChangeTextDo
 
 	uri := params.TextDocument.URI
 	contents := []byte(params.ContentChanges[0].Text)
-	tree, err := query.Parse(ctx, contents)
-	if err != nil {
-		s.docs.Remove(uri)
-		return fmt.Errorf("could not parse file %q: %v", uri, err)
-	}
-
-	s.docs.Write(uri, contents, tree)
-	return nil
+	return s.docs.Write(ctx, uri, contents)
 }
 
 func (s *Server) DidSave(ctx context.Context, params *protocol.DidSaveTextDocumentParams) (err error) {
 	uri := params.TextDocument.URI
 	contents := []byte(params.Text)
-	tree, err := query.Parse(ctx, contents)
-	if err != nil {
-		return fmt.Errorf("could not parse file %q: %v", uri, err)
-	}
-
-	s.docs.Write(uri, contents, tree)
-	return nil
+	return s.docs.Write(ctx, uri, contents)
 }
 
 func (s *Server) DidClose(_ context.Context, params *protocol.DidCloseTextDocumentParams) (err error) {

--- a/pkg/server/text_document_sync.go
+++ b/pkg/server/text_document_sync.go
@@ -38,12 +38,12 @@ func (s *Server) DidClose(_ context.Context, params *protocol.DidCloseTextDocume
 }
 
 func (s *Server) publishDiagnostics(ctx context.Context, textDoc protocol.VersionedTextDocumentIdentifier, diags []protocol.Diagnostic) error {
-	if len(diags) > 0 {
-		return s.notifier.PublishDiagnostics(ctx, &protocol.PublishDiagnosticsParams{
-			URI:         textDoc.URI,
-			Version:     uint32(textDoc.Version),
-			Diagnostics: diags,
-		})
+	if diags == nil {
+		diags = []protocol.Diagnostic{}
 	}
-	return nil
+	return s.notifier.PublishDiagnostics(ctx, &protocol.PublishDiagnosticsParams{
+		URI:         textDoc.URI,
+		Version:     uint32(textDoc.Version),
+		Diagnostics: diags,
+	})
 }

--- a/pkg/server/text_document_sync_test.go
+++ b/pkg/server/text_document_sync_test.go
@@ -1,6 +1,7 @@
 package server_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -74,7 +75,7 @@ func TestServer_DidClose(t *testing.T) {
 		TextDocument: protocol.TextDocumentIdentifier{URI: uri.File("./test.star")},
 	}, &resp)
 
-	doc, err := f.docManager.Read(uri.File("./test.star"))
-	require.EqualError(t, err, "file does not exist", "Document should no longer exist")
+	doc, err := f.docManager.Read(f.ctx, uri.File("./test.star"))
+	require.ErrorIs(t, os.ErrNotExist, err, "file does not exist", "Document should no longer exist")
 	require.Zero(t, doc, "Document was not zero-value")
 }


### PR DESCRIPTION
- analysis: extract NodesToContent and availableSymbols
- query: decouple from document package; extract DocumentContent
- document: move parsing to manager Read/Write
- document: associate functions and symbols to a document
- document: pre-parse symbols at document creation time
- document: build out manager internal parse routines
- document: add diagnostics and publish them on DidChange
- document: attempt to canonicalize URIs
- document: stub out processLoads and circular loading
- query: LoadStatements
- document: processLoads parses and follows load statements
- document: add uri
- document: resolve relative paths to doc.uri or workspace folder
- server: ensure empty slice to clear diagnostics
