### PR TITLE
cli: create command with document manager options

### DIFF
--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -10,6 +10,8 @@ import (
 	"go.lsp.dev/protocol"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/tilt-dev/starlark-lsp/pkg/document"
 )
 
 var logLevel = zap.NewAtomicLevelAt(zapcore.WarnLevel)
@@ -25,7 +27,8 @@ type RootCmd struct {
 //   commandName: what to call the base command in examples (e.g., "starlark-lsp", "tilt lsp")
 //   builtinFSProvider: provides an fs.FS from which tilt builtin docs should be read
 //                    if nil, a --builtin-paths param will be added for specifying paths
-func NewRootCmd(commandName string, builtinFSProvider BuiltinFSProvider) *RootCmd {
+//   managerOpts: a variable number of ManagerOpt arguments to configure the document manager.
+func NewRootCmd(commandName string, builtinFSProvider BuiltinFSProvider, managerOpts ...document.ManagerOpt) *RootCmd {
 	cmd := RootCmd{
 		Command: &cobra.Command{
 			Use:   commandName,
@@ -44,7 +47,7 @@ func NewRootCmd(commandName string, builtinFSProvider BuiltinFSProvider) *RootCm
 		}
 	}
 
-	cmd.AddCommand(newStartCmd(commandName, builtinFSProvider).Command)
+	cmd.AddCommand(newStartCmd(commandName, builtinFSProvider, managerOpts...).Command)
 
 	return &cmd
 }

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -48,13 +48,14 @@ type BuiltinAnalyzerOptionProvider = func() analysis.AnalyzerOption
 type BuiltinFSProvider = func() fs.FS
 
 var builtinAnalyzerOption BuiltinAnalyzerOptionProvider = nil
+var providedManagerOptions []document.ManagerOpt
 
 // creates a new startCmd
 // params:
 //   commandName: what to call the base command in examples (e.g., "starlark-lsp", "tilt lsp")
 //   builtinFSProvider: provides an fs.FS from which tilt builtin docs should be read
 //                      if nil, a --builtin-paths param will be added for specifying paths
-func newStartCmd(baseCommandName string, builtinFSProvider BuiltinFSProvider) *startCmd {
+func newStartCmd(baseCommandName string, builtinFSProvider BuiltinFSProvider, managerOpts ...document.ManagerOpt) *startCmd {
 	cmd := startCmd{
 		Command: &cobra.Command{
 			Use:   "start",
@@ -82,6 +83,8 @@ For socket mode, pass the --address option.
 			return analysis.WithBuiltins(builtinFSProvider())
 		}
 	}
+
+	providedManagerOptions = managerOpts
 
 	var example bytes.Buffer
 	p := exampleTemplateParams{
@@ -179,7 +182,7 @@ func initializeConn(conn io.ReadWriteCloser, logger *zap.Logger) (jsonrpc2.Conn,
 }
 
 func createHandler(cancel context.CancelFunc, notifier protocol.Client, analyzer *analysis.Analyzer) jsonrpc2.Handler {
-	docManager := document.NewDocumentManager()
+	docManager := document.NewDocumentManager(providedManagerOptions...)
 	s := server.NewServer(cancel, notifier, docManager, analyzer)
 	h := s.Handler(server.StandardMiddleware...)
 	return h


### PR DESCRIPTION
Allow creating the LSP CLI command with custom manager options. With these changes, Tilt should be able to set the manager `ReadDocumentFunc` to a custom function that knows how to handle reading `ext://` modules.
