### PR TITLE
Completion includes function arguments as variables

### DIFF
--- a/pkg/analysis/analyzer.go
+++ b/pkg/analysis/analyzer.go
@@ -31,8 +31,8 @@ func NewAnalyzer(ctx context.Context, opts ...AnalyzerOption) (*Analyzer, error)
 		}
 	}
 
-	if len(analyzer.builtins.Signatures) != 0 {
-		logger.Debug("registered built-in functions", zap.Int("count", len(analyzer.builtins.Signatures)))
+	if len(analyzer.builtins.Functions) != 0 {
+		logger.Debug("registered built-in functions", zap.Int("count", len(analyzer.builtins.Functions)))
 	}
 	if len(analyzer.builtins.Symbols) != 0 {
 		logger.Debug("registered built-in symbols", zap.Int("count", len(analyzer.builtins.Symbols)))

--- a/pkg/analysis/analyzer.go
+++ b/pkg/analysis/analyzer.go
@@ -31,8 +31,8 @@ func NewAnalyzer(ctx context.Context, opts ...AnalyzerOption) (*Analyzer, error)
 		}
 	}
 
-	if len(analyzer.builtins.Functions) != 0 {
-		logger.Debug("registered built-in functions", zap.Int("count", len(analyzer.builtins.Functions)))
+	if len(analyzer.builtins.Signatures) != 0 {
+		logger.Debug("registered built-in functions", zap.Int("count", len(analyzer.builtins.Signatures)))
 	}
 	if len(analyzer.builtins.Symbols) != 0 {
 		logger.Debug("registered built-in symbols", zap.Int("count", len(analyzer.builtins.Symbols)))

--- a/pkg/analysis/builtins.go
+++ b/pkg/analysis/builtins.go
@@ -20,8 +20,8 @@ import (
 )
 
 type Builtins struct {
-	Signatures map[string]query.Signature
-	Symbols    []protocol.DocumentSymbol
+	Functions map[string]query.Signature
+	Symbols   []protocol.DocumentSymbol
 }
 
 //go:embed builtins.py
@@ -29,19 +29,19 @@ var StarlarkBuiltins []byte
 
 func NewBuiltins() *Builtins {
 	return &Builtins{
-		Signatures: make(map[string]query.Signature),
-		Symbols:    []protocol.DocumentSymbol{},
+		Functions: make(map[string]query.Signature),
+		Symbols:   []protocol.DocumentSymbol{},
 	}
 }
 
 func (b *Builtins) IsEmpty() bool {
-	return len(b.Signatures) == 0 && len(b.Symbols) == 0
+	return len(b.Functions) == 0 && len(b.Symbols) == 0
 }
 
 func (b *Builtins) Update(other *Builtins) {
-	if len(other.Signatures) > 0 {
-		for name, sig := range other.Signatures {
-			b.Signatures[name] = sig
+	if len(other.Functions) > 0 {
+		for name, fn := range other.Functions {
+			b.Functions[name] = fn
 		}
 	}
 	if len(other.Symbols) > 0 {
@@ -50,9 +50,9 @@ func (b *Builtins) Update(other *Builtins) {
 }
 
 func (b *Builtins) FunctionNames() []string {
-	names := make([]string, len(b.Signatures))
+	names := make([]string, len(b.Functions))
 	i := 0
-	for name := range b.Signatures {
+	for name := range b.Functions {
 		names[i] = name
 		i++
 	}
@@ -116,13 +116,13 @@ func LoadBuiltinsFromSource(ctx context.Context, contents []byte, path string) (
 	}
 
 	doc := document.NewDocument(uri.File(path), contents, tree)
-	docSignatures := doc.FunctionSignatures()
+	functions := doc.Functions()
 	symbols := doc.Symbols()
 	doc.Close()
 
 	return &Builtins{
-		Signatures: docSignatures,
-		Symbols:    symbols,
+		Functions: functions,
+		Symbols:   symbols,
 	}, nil
 }
 
@@ -222,8 +222,8 @@ func LoadBuiltinsFromFS(ctx context.Context, f fs.FS) (*Builtins, error) {
 }
 
 func copyBuiltinsToParent(mod, parentMod *Builtins, modName string) {
-	for name, fn := range mod.Signatures {
-		parentMod.Signatures[modName+"."+name] = fn
+	for name, fn := range mod.Functions {
+		parentMod.Functions[modName+"."+name] = fn
 	}
 
 	children := []protocol.DocumentSymbol{}

--- a/pkg/analysis/builtins.go
+++ b/pkg/analysis/builtins.go
@@ -21,7 +21,6 @@ import (
 
 type Builtins struct {
 	Signatures map[string]query.Signature
-	Functions  map[string]protocol.SignatureInformation
 	Symbols    []protocol.DocumentSymbol
 }
 
@@ -31,7 +30,6 @@ var StarlarkBuiltins []byte
 func NewBuiltins() *Builtins {
 	return &Builtins{
 		Signatures: make(map[string]query.Signature),
-		Functions:  make(map[string]protocol.SignatureInformation),
 		Symbols:    []protocol.DocumentSymbol{},
 	}
 }
@@ -44,7 +42,6 @@ func (b *Builtins) Update(other *Builtins) {
 	if len(other.Signatures) > 0 {
 		for name, sig := range other.Signatures {
 			b.Signatures[name] = sig
-			b.Functions[name] = other.Functions[name]
 		}
 	}
 	if len(other.Symbols) > 0 {
@@ -120,13 +117,11 @@ func LoadBuiltinsFromSource(ctx context.Context, contents []byte, path string) (
 
 	doc := document.NewDocument(uri.File(path), contents, tree)
 	docSignatures := doc.FunctionSignatures()
-	docFunctions := doc.Functions()
 	symbols := doc.Symbols()
 	doc.Close()
 
 	return &Builtins{
 		Signatures: docSignatures,
-		Functions:  docFunctions,
 		Symbols:    symbols,
 	}, nil
 }
@@ -229,7 +224,6 @@ func LoadBuiltinsFromFS(ctx context.Context, f fs.FS) (*Builtins, error) {
 func copyBuiltinsToParent(mod, parentMod *Builtins, modName string) {
 	for name, fn := range mod.Signatures {
 		parentMod.Signatures[modName+"."+name] = fn
-		parentMod.Functions[modName+"."+name] = mod.Functions[name]
 	}
 
 	children := []protocol.DocumentSymbol{}

--- a/pkg/analysis/builtins_test.go
+++ b/pkg/analysis/builtins_test.go
@@ -235,7 +235,7 @@ func (f *fixture) Symbols(names ...string) {
 }
 
 func (f *fixture) AddFunction(name string, content string) {
-	f.builtins.Signatures[name] = query.Signature{
+	f.builtins.Functions[name] = query.Signature{
 		Name: name,
 		Docs: docstring.Parsed{Description: content},
 	}

--- a/pkg/analysis/builtins_test.go
+++ b/pkg/analysis/builtins_test.go
@@ -239,10 +239,6 @@ func (f *fixture) AddFunction(name string, content string) {
 		Name: name,
 		Docs: docstring.Parsed{Description: content},
 	}
-	f.builtins.Functions[name] = protocol.SignatureInformation{
-		Label:         name,
-		Documentation: content,
-	}
 	f.AddSymbol(name, content)
 }
 

--- a/pkg/analysis/builtins_test.go
+++ b/pkg/analysis/builtins_test.go
@@ -18,6 +18,7 @@ import (
 	"go.lsp.dev/protocol"
 	"go.uber.org/zap/zaptest"
 
+	"github.com/tilt-dev/starlark-lsp/pkg/docstring"
 	"github.com/tilt-dev/starlark-lsp/pkg/document"
 	"github.com/tilt-dev/starlark-lsp/pkg/query"
 )
@@ -234,6 +235,10 @@ func (f *fixture) Symbols(names ...string) {
 }
 
 func (f *fixture) AddFunction(name string, content string) {
+	f.builtins.Signatures[name] = query.Signature{
+		Name: name,
+		Docs: docstring.Parsed{Description: content},
+	}
 	f.builtins.Functions[name] = protocol.SignatureInformation{
 		Label:         name,
 		Documentation: content,
@@ -287,10 +292,7 @@ func newFixture(t *testing.T) *fixture {
 	})
 	ctx = protocol.WithLogger(ctx, logger)
 
-	builtins := &Builtins{
-		Functions: make(map[string]protocol.SignatureInformation),
-		Symbols:   []protocol.DocumentSymbol{},
-	}
+	builtins := NewBuiltins()
 	a, _ := NewAnalyzer(ctx)
 	a.builtins = builtins
 

--- a/pkg/analysis/completion.go
+++ b/pkg/analysis/completion.go
@@ -2,7 +2,6 @@ package analysis
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
 	"go.lsp.dev/protocol"
@@ -260,26 +259,17 @@ func (a *Analyzer) leafNodesForCompletion(doc document.Document, node *sitter.No
 	return nodes, true
 }
 
-// TODO: retain parsed function and parameter data so it doesn't need to be
-// parsed out of ParameterInformation.Label
-var paramName = regexp.MustCompile(`^(\w+)`)
-
-func (a *Analyzer) keywordArgSymbols(fn protocol.SignatureInformation, args callArguments) []protocol.DocumentSymbol {
+func (a *Analyzer) keywordArgSymbols(fn query.Signature, args callArguments) []protocol.DocumentSymbol {
 	symbols := []protocol.DocumentSymbol{}
-	for i, param := range fn.Parameters {
+	for i, param := range fn.Params {
 		if i < int(args.positional) {
 			continue
 		}
-		label := param.Label
-		match := paramName.FindSubmatch([]byte(label))
-		if match == nil {
-			continue
-		}
-		kwarg := string(match[1])
+		kwarg := param.Name
 		if used := args.keywords[kwarg]; !used {
 			symbols = append(symbols, protocol.DocumentSymbol{
 				Name:   kwarg + "=",
-				Detail: param.Label,
+				Detail: param.Content,
 				Kind:   protocol.SymbolKindVariable,
 			})
 		}

--- a/pkg/analysis/hover.go
+++ b/pkg/analysis/hover.go
@@ -16,11 +16,7 @@ func (a *Analyzer) Hover(ctx context.Context, doc document.Document, pos protoco
 		return nil
 	}
 
-	symbols := []protocol.DocumentSymbol{}
-	if ok {
-		symbols = a.completeExpression(doc, nodes, pt)
-	}
-
+	symbols := a.completeExpression(doc, nodes, pt)
 	var symbol protocol.DocumentSymbol
 	limit := nodes[len(nodes)-1].EndPoint()
 	identifiers := query.ExtractIdentifiers(doc, nodes, &limit)

--- a/pkg/analysis/signature.go
+++ b/pkg/analysis/signature.go
@@ -20,11 +20,11 @@ func (a *Analyzer) signatureInformation(doc document.Document, node *sitter.Node
 	}
 
 	if !found {
-		sig, found = doc.FunctionSignatures()[fnName]
+		sig, found = doc.Functions()[fnName]
 	}
 
 	if !found {
-		sig = a.builtins.Signatures[fnName]
+		sig = a.builtins.Functions[fnName]
 	}
 
 	return sig, sig.Name != ""

--- a/pkg/analysis/signature.go
+++ b/pkg/analysis/signature.go
@@ -8,8 +8,8 @@ import (
 	"github.com/tilt-dev/starlark-lsp/pkg/query"
 )
 
-func (a *Analyzer) signatureInformation(doc document.Document, node *sitter.Node, fnName string) (protocol.SignatureInformation, bool) {
-	var sig protocol.SignatureInformation
+func (a *Analyzer) signatureInformation(doc document.Document, node *sitter.Node, fnName string) (query.Signature, bool) {
+	var sig query.Signature
 	var found bool
 
 	for n := node; n != nil && !query.IsModuleScope(doc, n); n = n.Parent() {
@@ -20,14 +20,14 @@ func (a *Analyzer) signatureInformation(doc document.Document, node *sitter.Node
 	}
 
 	if !found {
-		sig, found = doc.Functions()[fnName]
+		sig, found = doc.FunctionSignatures()[fnName]
 	}
 
 	if !found {
-		sig = a.builtins.Functions[fnName]
+		sig = a.builtins.Signatures[fnName]
 	}
 
-	return sig, sig.Label != ""
+	return sig, sig.Name != ""
 }
 
 func (a *Analyzer) SignatureHelp(doc document.Document, pos protocol.Position) *protocol.SignatureHelp {
@@ -54,12 +54,12 @@ func (a *Analyzer) SignatureHelp(doc document.Document, pos protocol.Position) *
 		activeParam = args.positional
 	}
 
-	if activeParam > uint32(len(sig.Parameters)-1) {
-		activeParam = uint32(len(sig.Parameters) - 1)
+	if activeParam > uint32(len(sig.Params)-1) {
+		activeParam = uint32(len(sig.Params) - 1)
 	}
 
 	return &protocol.SignatureHelp{
-		Signatures:      []protocol.SignatureInformation{sig},
+		Signatures:      []protocol.SignatureInformation{sig.SignatureInfo()},
 		ActiveParameter: activeParam,
 		ActiveSignature: 0,
 	}

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -34,7 +34,6 @@ type Document interface {
 
 	Tree() *sitter.Tree
 	FunctionSignatures() map[string]query.Signature
-	Functions() map[string]protocol.SignatureInformation
 	Symbols() []protocol.DocumentSymbol
 	Diagnostics() []protocol.Diagnostic
 	Loads() []LoadStatement
@@ -53,10 +52,6 @@ func NewDocument(u uri.URI, input []byte, tree *sitter.Tree) Document {
 		tree:  tree,
 	}
 	doc.signatures = query.Functions(doc, tree.RootNode())
-	doc.functions = make(map[string]protocol.SignatureInformation, len(doc.signatures))
-	for name, sig := range doc.signatures {
-		doc.functions[name] = sig.SignatureInfo()
-	}
 	doc.symbols = query.DocumentSymbols(doc)
 	doc.parseLoadStatements()
 	return doc
@@ -87,7 +82,6 @@ type document struct {
 	tree *sitter.Tree
 
 	signatures  map[string]query.Signature
-	functions   map[string]protocol.SignatureInformation
 	symbols     []protocol.DocumentSymbol
 	diagnostics []protocol.Diagnostic
 	loads       []LoadStatement
@@ -113,10 +107,6 @@ func (d *document) Tree() *sitter.Tree {
 
 func (d *document) FunctionSignatures() map[string]query.Signature {
 	return d.signatures
-}
-
-func (d *document) Functions() map[string]protocol.SignatureInformation {
-	return d.functions
 }
 
 func (d *document) Symbols() []protocol.DocumentSymbol {
@@ -145,14 +135,12 @@ func (d *document) Copy() Document {
 		input:       d.input,
 		tree:        d.tree.Copy(),
 		signatures:  make(map[string]query.Signature),
-		functions:   make(map[string]protocol.SignatureInformation),
 		symbols:     append([]protocol.DocumentSymbol{}, d.symbols...),
 		loads:       append([]LoadStatement{}, d.loads...),
 		diagnostics: append([]protocol.Diagnostic{}, d.diagnostics...),
 	}
 	for fn, sig := range d.signatures {
 		doc.signatures[fn] = sig
-		doc.functions[fn] = d.functions[fn]
 	}
 	return doc
 }

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -199,7 +199,7 @@ func (d *document) followLoads(ctx context.Context, m *Manager, parseState Docum
 }
 
 func (d *document) processLoad(dep Document, load LoadStatement) {
-	fns := dep.Functions()
+	fns := dep.FunctionSignatures()
 	symMap := make(map[string]protocol.DocumentSymbol)
 	for _, s := range dep.Symbols() {
 		symMap[s.Name] = s
@@ -210,7 +210,7 @@ func (d *document) processLoad(dep Document, load LoadStatement) {
 			sym.Range = ls.Range
 			d.symbols = append(d.symbols, sym)
 			if f, ok := fns[ls.Name]; ok {
-				d.functions[ls.Alias] = f
+				d.signatures[ls.Alias] = f
 			}
 		} else {
 			d.diagnostics = append(d.diagnostics, protocol.Diagnostic{

--- a/pkg/query/params.go
+++ b/pkg/query/params.go
@@ -46,6 +46,15 @@ func (p parameter) paramInfo(fnDocs docstring.Parsed) protocol.ParameterInformat
 	return pi
 }
 
+func (p parameter) symbol() protocol.DocumentSymbol {
+	return protocol.DocumentSymbol{
+		Name:   p.name,
+		Kind:   protocol.SymbolKindVariable,
+		Detail: p.content,
+		Range:  NodeRange(p.node),
+	}
+}
+
 func extractParameters(doc DocumentContent, fnDocs docstring.Parsed,
 	node *sitter.Node) []parameter {
 	if node.Type() != NodeTypeParameters {

--- a/pkg/query/params.go
+++ b/pkg/query/params.go
@@ -10,19 +10,19 @@ import (
 	"github.com/tilt-dev/starlark-lsp/pkg/docstring"
 )
 
-type parameter struct {
-	name         string
-	typeHint     string
-	defaultValue string
-	content      string
-	node         *sitter.Node
+type Parameter struct {
+	Name         string
+	TypeHint     string
+	DefaultValue string
+	Content      string
+	Node         *sitter.Node
 }
 
-func (p parameter) paramInfo(fnDocs docstring.Parsed) protocol.ParameterInformation {
+func (p Parameter) ParameterInfo(fnDocs docstring.Parsed) protocol.ParameterInformation {
 	// TODO(milas): revisit labels - with type hints this can make signatures
 	// 	really long; it might make sense to only include param name and default
 	// 	value (if any)
-	pi := protocol.ParameterInformation{Label: p.content}
+	pi := protocol.ParameterInformation{Label: p.Content}
 
 	var docContent string
 	for _, fieldsBlock := range fnDocs.Fields {
@@ -30,7 +30,7 @@ func (p parameter) paramInfo(fnDocs docstring.Parsed) protocol.ParameterInformat
 			continue
 		}
 		for _, f := range fieldsBlock.Fields {
-			if f.Name == p.name {
+			if f.Name == p.Name {
 				docContent = f.Desc
 			}
 		}
@@ -46,17 +46,17 @@ func (p parameter) paramInfo(fnDocs docstring.Parsed) protocol.ParameterInformat
 	return pi
 }
 
-func (p parameter) symbol() protocol.DocumentSymbol {
+func (p Parameter) Symbol() protocol.DocumentSymbol {
 	return protocol.DocumentSymbol{
-		Name:   p.name,
+		Name:   p.Name,
 		Kind:   protocol.SymbolKindVariable,
-		Detail: p.content,
-		Range:  NodeRange(p.node),
+		Detail: p.Content,
+		Range:  NodeRange(p.Node),
 	}
 }
 
 func extractParameters(doc DocumentContent, fnDocs docstring.Parsed,
-	node *sitter.Node) []parameter {
+	node *sitter.Node) []Parameter {
 	if node.Type() != NodeTypeParameters {
 		// A query is used here because there's several different node types
 		// for parameter values, and the query handles normalization gracefully
@@ -72,22 +72,22 @@ func extractParameters(doc DocumentContent, fnDocs docstring.Parsed,
 		panic(fmt.Errorf("invalid node type: %v", node.Type()))
 	}
 
-	var params []parameter
+	var params []Parameter
 	Query(node, FunctionParameters, func(q *sitter.Query, match *sitter.QueryMatch) bool {
-		var param parameter
+		var param Parameter
 
 		for _, c := range match.Captures {
 			content := doc.Content(c.Node)
 			switch q.CaptureNameForId(c.Index) {
 			case "name":
-				param.name = content
+				param.Name = content
 			case "type":
-				param.typeHint = content
+				param.TypeHint = content
 			case "value":
-				param.defaultValue = content
+				param.DefaultValue = content
 			case "param":
-				param.content = content
-				param.node = c.Node
+				param.Content = content
+				param.Node = c.Node
 			}
 		}
 

--- a/pkg/query/params.go
+++ b/pkg/query/params.go
@@ -15,6 +15,7 @@ type parameter struct {
 	typeHint     string
 	defaultValue string
 	content      string
+	node         *sitter.Node
 }
 
 func (p parameter) paramInfo(fnDocs docstring.Parsed) protocol.ParameterInformation {
@@ -46,7 +47,7 @@ func (p parameter) paramInfo(fnDocs docstring.Parsed) protocol.ParameterInformat
 }
 
 func extractParameters(doc DocumentContent, fnDocs docstring.Parsed,
-	node *sitter.Node) []protocol.ParameterInformation {
+	node *sitter.Node) []parameter {
 	if node.Type() != NodeTypeParameters {
 		// A query is used here because there's several different node types
 		// for parameter values, and the query handles normalization gracefully
@@ -62,7 +63,7 @@ func extractParameters(doc DocumentContent, fnDocs docstring.Parsed,
 		panic(fmt.Errorf("invalid node type: %v", node.Type()))
 	}
 
-	var params []protocol.ParameterInformation
+	var params []parameter
 	Query(node, FunctionParameters, func(q *sitter.Query, match *sitter.QueryMatch) bool {
 		var param parameter
 
@@ -77,10 +78,11 @@ func extractParameters(doc DocumentContent, fnDocs docstring.Parsed,
 				param.defaultValue = content
 			case "param":
 				param.content = content
+				param.node = c.Node
 			}
 		}
 
-		params = append(params, param.paramInfo(fnDocs))
+		params = append(params, param)
 		return true
 	})
 	return params

--- a/pkg/query/signature.go
+++ b/pkg/query/signature.go
@@ -54,6 +54,7 @@ type signature struct {
 	params     []parameter
 	returnType string
 	docs       docstring.Parsed
+	node       *sitter.Node
 }
 
 func (s signature) signatureInfo() protocol.SignatureInformation {
@@ -95,6 +96,15 @@ func (s signature) label() string {
 	return sb.String()
 }
 
+func (s signature) symbol() protocol.DocumentSymbol {
+	return protocol.DocumentSymbol{
+		Name:   s.name,
+		Kind:   protocol.SymbolKindFunction,
+		Detail: s.label(),
+		Range:  NodeRange(s.node),
+	}
+}
+
 func extractSignature(doc DocumentContent, n *sitter.Node) signature {
 	if n.Type() != NodeTypeFunctionDef {
 		panic(fmt.Errorf("invalid node type: %s", n.Type()))
@@ -111,14 +121,13 @@ func extractSignature(doc DocumentContent, n *sitter.Node) signature {
 		returnType = doc.Content(rtNode)
 	}
 
-	sig := signature{
+	return signature{
 		name:       fnName,
 		params:     params,
 		returnType: returnType,
 		docs:       fnDocs,
+		node:       n,
 	}
-
-	return sig
 }
 
 func extractDocstring(doc DocumentContent, n *sitter.Node) docstring.Parsed {

--- a/pkg/query/symbol.go
+++ b/pkg/query/symbol.go
@@ -45,17 +45,8 @@ func SiblingSymbols(doc DocumentContent, node, before *sitter.Node) []protocol.D
 
 		if n.Type() == NodeTypeFunctionDef {
 			sig := extractSignature(doc, n)
-			sigInfo := sig.signatureInfo()
-			symbol.Name = sig.name
-			symbol.Kind = protocol.SymbolKindFunction
-			if sigInfo.Documentation != nil {
-				if s, ok := sigInfo.Documentation.(protocol.MarkupContent); ok {
-					symbol.Detail = s.Value
-				} else {
-					symbol.Detail = sigInfo.Documentation.(string)
-				}
-			}
-			symbol.Range = NodeRange(n)
+			symbol = sig.symbol()
+			symbol.Detail = sig.docs.Description
 		}
 
 		if symbol.Name != "" {
@@ -84,12 +75,7 @@ func SymbolsInScope(doc DocumentContent, node *sitter.Node) []protocol.DocumentS
 	appendParameters := func(fnNode *sitter.Node) {
 		sig := extractSignature(doc, fnNode)
 		for _, p := range sig.params {
-			symbols = append(symbols, protocol.DocumentSymbol{
-				Name:   p.name,
-				Kind:   protocol.SymbolKindVariable,
-				Detail: p.paramInfo(sig.docs).Label,
-				Range:  NodeRange(p.node),
-			})
+			symbols = append(symbols, p.symbol())
 		}
 	}
 

--- a/pkg/query/symbol.go
+++ b/pkg/query/symbol.go
@@ -44,8 +44,9 @@ func SiblingSymbols(doc DocumentContent, node, before *sitter.Node) []protocol.D
 		}
 
 		if n.Type() == NodeTypeFunctionDef {
-			name, sigInfo := extractSignatureInformation(doc, n)
-			symbol.Name = name
+			sig := extractSignature(doc, n)
+			sigInfo := sig.signatureInfo()
+			symbol.Name = sig.name
 			symbol.Kind = protocol.SymbolKindFunction
 			if sigInfo.Documentation != nil {
 				if s, ok := sigInfo.Documentation.(protocol.MarkupContent); ok {
@@ -79,18 +80,37 @@ func IsModuleScope(doc DocumentContent, node *sitter.Node) bool {
 // excluding symbols from the top-level module (document symbols).
 func SymbolsInScope(doc DocumentContent, node *sitter.Node) []protocol.DocumentSymbol {
 	var symbols []protocol.DocumentSymbol
+
+	appendParameters := func(fnNode *sitter.Node) {
+		sig := extractSignature(doc, fnNode)
+		for _, p := range sig.params {
+			symbols = append(symbols, protocol.DocumentSymbol{
+				Name:   p.name,
+				Kind:   protocol.SymbolKindVariable,
+				Detail: p.paramInfo(sig.docs).Label,
+				Range:  NodeRange(p.node),
+			})
+		}
+	}
+
 	// While we are in the current scope, only include symbols defined before
 	// the provided node.
 	before := node
-	for n := node; n.Parent() != nil && !IsModuleScope(doc, n); n = n.Parent() {
+	n := node
+	for ; n.Parent() != nil && !IsModuleScope(doc, n); n = n.Parent() {
 		// A function definition creates an enclosing scope, where all symbols
 		// in the parent scope are visible. After that point, don't specify a
 		// before node.
 		if n.Type() == NodeTypeFunctionDef {
 			before = nil
+			appendParameters(n)
 		}
 
 		symbols = append(symbols, SiblingSymbols(doc, n.Parent().NamedChild(0), before)...)
+	}
+	// Append parameters of parent function that's in module scope
+	if n.Type() == NodeTypeFunctionDef {
+		appendParameters(n)
 	}
 	return symbols
 }

--- a/pkg/query/symbol.go
+++ b/pkg/query/symbol.go
@@ -44,9 +44,9 @@ func SiblingSymbols(doc DocumentContent, node, before *sitter.Node) []protocol.D
 		}
 
 		if n.Type() == NodeTypeFunctionDef {
-			sig := extractSignature(doc, n)
-			symbol = sig.symbol()
-			symbol.Detail = sig.docs.Description
+			sig := ExtractSignature(doc, n)
+			symbol = sig.Symbol()
+			symbol.Detail = sig.Docs.Description
 		}
 
 		if symbol.Name != "" {
@@ -73,9 +73,9 @@ func SymbolsInScope(doc DocumentContent, node *sitter.Node) []protocol.DocumentS
 	var symbols []protocol.DocumentSymbol
 
 	appendParameters := func(fnNode *sitter.Node) {
-		sig := extractSignature(doc, fnNode)
-		for _, p := range sig.params {
-			symbols = append(symbols, p.symbol())
+		sig := ExtractSignature(doc, fnNode)
+		for _, p := range sig.Params {
+			symbols = append(symbols, p.Symbol())
 		}
 	}
 

--- a/pkg/server/fixture_test.go
+++ b/pkg/server/fixture_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tilt-dev/starlark-lsp/pkg/analysis"
 	"github.com/tilt-dev/starlark-lsp/pkg/document"
 	"github.com/tilt-dev/starlark-lsp/pkg/middleware"
+	"github.com/tilt-dev/starlark-lsp/pkg/query"
 	"github.com/tilt-dev/starlark-lsp/pkg/server"
 )
 
@@ -262,6 +263,10 @@ func (t *testDocument) ContentRange(r sitter.Range) string {
 
 func (t *testDocument) Tree() *sitter.Tree {
 	return t.doc.Tree()
+}
+
+func (t *testDocument) FunctionSignatures() map[string]query.Signature {
+	return t.doc.FunctionSignatures()
 }
 
 func (t *testDocument) Functions() map[string]protocol.SignatureInformation {

--- a/pkg/server/fixture_test.go
+++ b/pkg/server/fixture_test.go
@@ -265,8 +265,8 @@ func (t *testDocument) Tree() *sitter.Tree {
 	return t.doc.Tree()
 }
 
-func (t *testDocument) FunctionSignatures() map[string]query.Signature {
-	return t.doc.FunctionSignatures()
+func (t *testDocument) Functions() map[string]query.Signature {
+	return t.doc.Functions()
 }
 
 func (t *testDocument) Symbols() []protocol.DocumentSymbol {

--- a/pkg/server/fixture_test.go
+++ b/pkg/server/fixture_test.go
@@ -269,10 +269,6 @@ func (t *testDocument) FunctionSignatures() map[string]query.Signature {
 	return t.doc.FunctionSignatures()
 }
 
-func (t *testDocument) Functions() map[string]protocol.SignatureInformation {
-	return t.doc.Functions()
-}
-
 func (t *testDocument) Symbols() []protocol.DocumentSymbol {
 	return t.doc.Symbols()
 }

--- a/pkg/server/signature_test.go
+++ b/pkg/server/signature_test.go
@@ -81,7 +81,7 @@ foo(a,
 	expected := protocol.SignatureHelp{
 		Signatures: []protocol.SignatureInformation{
 			{
-				Label: `(a, b) -> None`,
+				Label: `(a, b)`,
 				Parameters: []protocol.ParameterInformation{
 					{Label: "a"},
 					{Label: "b"},


### PR DESCRIPTION
Also convert doc/builtin function data to internal struct with richer info and only convert to protocol structs when needed. This let me remove the regexp parsing in completion keyword arg processing.