### PR TITLE
lsp: calculate hover by symbol rather than function call

### DIFF
--- a/pkg/analysis/builtins_test.go
+++ b/pkg/analysis/builtins_test.go
@@ -238,6 +238,22 @@ func (f *fixture) AddFunction(name string, content string) {
 		Label:         name,
 		Documentation: content,
 	}
+	f.AddSymbol(name, content)
+}
+
+func (f *fixture) AddSymbol(name string, content string) {
+	ids := strings.Split(name, ".")
+	var cur protocol.DocumentSymbol
+	for i := len(ids) - 1; i >= 0; i-- {
+		s := protocol.DocumentSymbol{Name: ids[i]}
+		if i == len(ids)-1 {
+			s.Detail = content
+		} else {
+			s.Children = []protocol.DocumentSymbol{cur}
+		}
+		cur = s
+	}
+	f.builtins.Symbols = append(f.builtins.Symbols, cur)
 }
 
 func (f *fixture) Symbol(name string) protocol.DocumentSymbol {

--- a/pkg/analysis/completion.go
+++ b/pkg/analysis/completion.go
@@ -71,9 +71,10 @@ func (a *Analyzer) Completion(doc document.Document, pos protocol.Position) *pro
 		} else {
 			sortText = fmt.Sprintf("1%s", sym.Name)
 		}
+		firstDetailLine := strings.SplitN(sym.Detail, "\n", 2)[0]
 		completionList.Items[i] = protocol.CompletionItem{
 			Label:    sym.Name,
-			Detail:   sym.Detail,
+			Detail:   firstDetailLine,
 			Kind:     ToCompletionItemKind(sym.Kind),
 			SortText: sortText,
 		}

--- a/pkg/analysis/hover.go
+++ b/pkg/analysis/hover.go
@@ -3,8 +3,6 @@ package analysis
 import (
 	"context"
 
-	sitter "github.com/smacker/go-tree-sitter"
-
 	"go.lsp.dev/protocol"
 
 	"github.com/tilt-dev/starlark-lsp/pkg/document"
@@ -13,46 +11,39 @@ import (
 
 func (a *Analyzer) Hover(ctx context.Context, doc document.Document, pos protocol.Position) *protocol.Hover {
 	pt := query.PositionToPoint(pos)
-	node, ok := query.NodeAtPoint(doc, pt)
+	nodes, ok := a.nodesAtPointForCompletion(doc, pt)
 	if !ok {
 		return nil
 	}
 
-	var sig protocol.SignatureInformation
-	var hoverNode *sitter.Node
-	for cur := node; cur != nil; cur = cur.Parent() {
-		if cur.Type() != "call" {
-			continue
-		}
-		// TODO - show hover for vars
-		var found bool
-		fnName := doc.Content(cur.ChildByFieldName("function"))
-		sig, found = a.signatureInformation(doc, node, fnName)
-		if found {
-			hoverNode = cur
-			break
+	symbols := []protocol.DocumentSymbol{}
+	if ok {
+		symbols = a.completeExpression(doc, nodes, pt)
+	}
+
+	var symbol protocol.DocumentSymbol
+	limit := nodes[len(nodes)-1].EndPoint()
+	identifiers := query.ExtractIdentifiers(doc, nodes, &limit)
+	if len(identifiers) == 0 {
+		return nil
+	}
+	for _, s := range symbols {
+		if s.Name == identifiers[len(identifiers)-1] {
+			symbol = s
 		}
 	}
 
-	d := sig.Documentation
-
-	if d == nil {
+	if symbol.Name == "" {
 		return nil
 	}
 
-	r := query.NodeRange(hoverNode)
+	r := query.NodesRange(nodes)
 	result := &protocol.Hover{
 		Range: &r,
-	}
-
-	if mc, ok := d.(protocol.MarkupContent); ok {
-		result.Contents = mc
-	} else {
-		result.Contents = protocol.MarkupContent{
+		Contents: protocol.MarkupContent{
 			Kind:  protocol.PlainText,
-			Value: d.(string),
-		}
+			Value: symbol.Detail,
+		},
 	}
-
 	return result
 }

--- a/pkg/query/location.go
+++ b/pkg/query/location.go
@@ -28,6 +28,22 @@ func NodeRange(node *sitter.Node) protocol.Range {
 	}
 }
 
+func NodesRange(nodes []*sitter.Node) protocol.Range {
+	var start, end sitter.Point
+	for i, n := range nodes {
+		if i == 0 || PointBefore(start, n.StartPoint()) {
+			start = n.StartPoint()
+		}
+		if i == 0 || PointAfter(end, n.EndPoint()) {
+			end = n.EndPoint()
+		}
+	}
+	return protocol.Range{
+		Start: pointToPosition(start),
+		End:   pointToPosition(end),
+	}
+}
+
 func PointCmp(a, b sitter.Point) int {
 	if a.Row < b.Row {
 		return -1

--- a/pkg/query/symbol.go
+++ b/pkg/query/symbol.go
@@ -47,7 +47,13 @@ func SiblingSymbols(doc DocumentContent, node, before *sitter.Node) []protocol.D
 			name, sigInfo := extractSignatureInformation(doc, n)
 			symbol.Name = name
 			symbol.Kind = protocol.SymbolKindFunction
-			symbol.Detail = sigInfo.Label
+			if sigInfo.Documentation != nil {
+				if s, ok := sigInfo.Documentation.(protocol.MarkupContent); ok {
+					symbol.Detail = s.Value
+				} else {
+					symbol.Detail = sigInfo.Documentation.(string)
+				}
+			}
 			symbol.Range = NodeRange(n)
 		}
 

--- a/pkg/server/hover.go
+++ b/pkg/server/hover.go
@@ -15,7 +15,7 @@ func (s *Server) Hover(ctx context.Context, params *protocol.HoverParams) (resul
 
 	logger := protocol.LoggerFromContext(ctx).
 		With(textDocumentFields(params.TextDocumentPositionParams)...)
-	logger.Debug("completion")
+	logger.Debug("hover")
 
 	return s.analyzer.Hover(ctx, doc, params.Position), nil
 }


### PR DESCRIPTION
The existing hover implementation only matches syntactically valid function calls.

This PR allows Tilt to match on variables, attributes, and function calls that don't yet have parentheses.