### PR TITLE
starlark-lsp: swap out protocol.DocumentSymbol with query.Symbol

### DIFF
--- a/pkg/analysis/builtins.go
+++ b/pkg/analysis/builtins.go
@@ -21,7 +21,7 @@ import (
 
 type Builtins struct {
 	Functions map[string]query.Signature
-	Symbols   []protocol.DocumentSymbol
+	Symbols   []query.Symbol
 }
 
 //go:embed builtins.py
@@ -30,7 +30,7 @@ var StarlarkBuiltins []byte
 func NewBuiltins() *Builtins {
 	return &Builtins{
 		Functions: make(map[string]query.Signature),
-		Symbols:   []protocol.DocumentSymbol{},
+		Symbols:   []query.Symbol{},
 	}
 }
 
@@ -98,7 +98,7 @@ func WithStarlarkBuiltins() AnalyzerOption {
 			return errors.Wrapf(err, "loading builtins from builtins.py")
 		}
 		analyzer.builtins.Update(&Builtins{
-			Symbols: []protocol.DocumentSymbol{
+			Symbols: []query.Symbol{
 				{Name: "False", Kind: protocol.SymbolKindBoolean},
 				{Name: "None", Kind: protocol.SymbolKindNull},
 				{Name: "True", Kind: protocol.SymbolKindBoolean},
@@ -226,7 +226,7 @@ func copyBuiltinsToParent(mod, parentMod *Builtins, modName string) {
 		parentMod.Functions[modName+"."+name] = fn
 	}
 
-	children := []protocol.DocumentSymbol{}
+	children := []query.Symbol{}
 	for _, sym := range mod.Symbols {
 		var kind protocol.SymbolKind
 		switch sym.Kind {
@@ -252,7 +252,7 @@ func copyBuiltinsToParent(mod, parentMod *Builtins, modName string) {
 		if existingIndex >= 0 {
 			parentMod.Symbols[existingIndex].Children = append(parentMod.Symbols[existingIndex].Children, children...)
 		} else {
-			parentMod.Symbols = append(parentMod.Symbols, protocol.DocumentSymbol{
+			parentMod.Symbols = append(parentMod.Symbols, query.Symbol{
 				Name:     modName,
 				Kind:     protocol.SymbolKindVariable,
 				Children: children,

--- a/pkg/analysis/builtins_test.go
+++ b/pkg/analysis/builtins_test.go
@@ -244,21 +244,21 @@ func (f *fixture) AddFunction(name string, content string) {
 
 func (f *fixture) AddSymbol(name string, content string) {
 	ids := strings.Split(name, ".")
-	var cur protocol.DocumentSymbol
+	var cur query.Symbol
 	for i := len(ids) - 1; i >= 0; i-- {
-		s := protocol.DocumentSymbol{Name: ids[i]}
+		s := query.Symbol{Name: ids[i]}
 		if i == len(ids)-1 {
 			s.Detail = content
 		} else {
-			s.Children = []protocol.DocumentSymbol{cur}
+			s.Children = []query.Symbol{cur}
 		}
 		cur = s
 	}
 	f.builtins.Symbols = append(f.builtins.Symbols, cur)
 }
 
-func (f *fixture) Symbol(name string) protocol.DocumentSymbol {
-	return protocol.DocumentSymbol{
+func (f *fixture) Symbol(name string) query.Symbol {
+	return query.Symbol{
 		Name: name,
 		Kind: protocol.SymbolKindVariable,
 	}

--- a/pkg/analysis/completion.go
+++ b/pkg/analysis/completion.go
@@ -13,20 +13,20 @@ import (
 	"github.com/tilt-dev/starlark-lsp/pkg/query"
 )
 
-func SymbolMatching(symbols []protocol.DocumentSymbol, name string) protocol.DocumentSymbol {
+func SymbolMatching(symbols []query.Symbol, name string) query.Symbol {
 	for _, sym := range symbols {
 		if sym.Name == name {
 			return sym
 		}
 	}
-	return protocol.DocumentSymbol{}
+	return query.Symbol{}
 }
 
-func SymbolsStartingWith(symbols []protocol.DocumentSymbol, prefix string) []protocol.DocumentSymbol {
+func SymbolsStartingWith(symbols []query.Symbol, prefix string) []query.Symbol {
 	if prefix == "" {
 		return symbols
 	}
-	result := []protocol.DocumentSymbol{}
+	result := []query.Symbol{}
 	for _, sym := range symbols {
 		if strings.HasPrefix(sym.Name, prefix) {
 			result = append(result, sym)
@@ -51,7 +51,7 @@ func ToCompletionItemKind(k protocol.SymbolKind) protocol.CompletionItemKind {
 func (a *Analyzer) Completion(doc document.Document, pos protocol.Position) *protocol.CompletionList {
 	pt := query.PositionToPoint(pos)
 	nodes, ok := a.nodesAtPointForCompletion(doc, pt)
-	symbols := []protocol.DocumentSymbol{}
+	symbols := []query.Symbol{}
 
 	if ok {
 		symbols = a.completeExpression(doc, nodes, pt)
@@ -85,7 +85,7 @@ func (a *Analyzer) Completion(doc document.Document, pos protocol.Position) *pro
 	return completionList
 }
 
-func (a *Analyzer) completeExpression(doc document.Document, nodes []*sitter.Node, pt sitter.Point) []protocol.DocumentSymbol {
+func (a *Analyzer) completeExpression(doc document.Document, nodes []*sitter.Node, pt sitter.Point) []query.Symbol {
 	var nodeAtPoint *sitter.Node
 	if len(nodes) > 0 {
 		nodeAtPoint = nodes[len(nodes)-1]
@@ -132,8 +132,8 @@ func (a *Analyzer) completeExpression(doc document.Document, nodes []*sitter.Nod
 //   level (document symbols), because the document already has those computed
 // - Add document symbols
 // - Add builtins
-func (a *Analyzer) availableSymbols(doc document.Document, nodeAtPoint *sitter.Node, pt sitter.Point) []protocol.DocumentSymbol {
-	symbols := []protocol.DocumentSymbol{}
+func (a *Analyzer) availableSymbols(doc document.Document, nodeAtPoint *sitter.Node, pt sitter.Point) []query.Symbol {
+	symbols := []query.Symbol{}
 	if nodeAtPoint != nil {
 		if fnName, args := keywordArgContext(doc, nodeAtPoint, pt); fnName != "" {
 			if fn, ok := a.signatureInformation(doc, nodeAtPoint, fnName); ok {
@@ -259,15 +259,15 @@ func (a *Analyzer) leafNodesForCompletion(doc document.Document, node *sitter.No
 	return nodes, true
 }
 
-func (a *Analyzer) keywordArgSymbols(fn query.Signature, args callArguments) []protocol.DocumentSymbol {
-	symbols := []protocol.DocumentSymbol{}
+func (a *Analyzer) keywordArgSymbols(fn query.Signature, args callArguments) []query.Symbol {
+	symbols := []query.Symbol{}
 	for i, param := range fn.Params {
 		if i < int(args.positional) {
 			continue
 		}
 		kwarg := param.Name
 		if used := args.keywords[kwarg]; !used {
-			symbols = append(symbols, protocol.DocumentSymbol{
+			symbols = append(symbols, query.Symbol{
 				Name:   kwarg + "=",
 				Detail: param.Content,
 				Kind:   protocol.SymbolKindVariable,

--- a/pkg/analysis/completion_test.go
+++ b/pkg/analysis/completion_test.go
@@ -16,11 +16,11 @@ func (f *fixture) builtinSymbols() {
 
 func (f *fixture) osSysSymbols() {
 	f.Symbols("os", "sys")
-	f.builtins.Symbols[0].Children = []protocol.DocumentSymbol{
+	f.builtins.Symbols[0].Children = []query.Symbol{
 		f.Symbol("environ"),
 		f.Symbol("name"),
 	}
-	f.builtins.Symbols[1].Children = []protocol.DocumentSymbol{
+	f.builtins.Symbols[1].Children = []query.Symbol{
 		f.Symbol("argv"),
 		f.Symbol("executable"),
 	}

--- a/pkg/analysis/hover.go
+++ b/pkg/analysis/hover.go
@@ -17,7 +17,7 @@ func (a *Analyzer) Hover(ctx context.Context, doc document.Document, pos protoco
 	}
 
 	symbols := a.completeExpression(doc, nodes, pt)
-	var symbol protocol.DocumentSymbol
+	var symbol query.Symbol
 	limit := nodes[len(nodes)-1].EndPoint()
 	identifiers := query.ExtractIdentifiers(doc, nodes, &limit)
 	if len(identifiers) == 0 {

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -34,9 +34,10 @@ type Document interface {
 
 	Tree() *sitter.Tree
 	Functions() map[string]query.Signature
-	Symbols() []protocol.DocumentSymbol
+	Symbols() []query.Symbol
 	Diagnostics() []protocol.Diagnostic
 	Loads() []LoadStatement
+	URI() uri.URI
 
 	Copy() Document
 
@@ -82,7 +83,7 @@ type document struct {
 	tree *sitter.Tree
 
 	functions   map[string]query.Signature
-	symbols     []protocol.DocumentSymbol
+	symbols     []query.Symbol
 	diagnostics []protocol.Diagnostic
 	loads       []LoadStatement
 }
@@ -109,7 +110,7 @@ func (d *document) Functions() map[string]query.Signature {
 	return d.functions
 }
 
-func (d *document) Symbols() []protocol.DocumentSymbol {
+func (d *document) Symbols() []query.Symbol {
 	return d.symbols
 }
 
@@ -119,6 +120,10 @@ func (d *document) Diagnostics() []protocol.Diagnostic {
 
 func (d *document) Loads() []LoadStatement {
 	return d.loads
+}
+
+func (d *document) URI() uri.URI {
+	return d.uri
 }
 
 func (d *document) Close() {
@@ -135,7 +140,7 @@ func (d *document) Copy() Document {
 		input:       d.input,
 		tree:        d.tree.Copy(),
 		functions:   make(map[string]query.Signature),
-		symbols:     append([]protocol.DocumentSymbol{}, d.symbols...),
+		symbols:     append([]query.Symbol{}, d.symbols...),
 		loads:       append([]LoadStatement{}, d.loads...),
 		diagnostics: append([]protocol.Diagnostic{}, d.diagnostics...),
 	}
@@ -188,14 +193,17 @@ func (d *document) followLoads(ctx context.Context, m *Manager, parseState Docum
 
 func (d *document) processLoad(dep Document, load LoadStatement) {
 	fns := dep.Functions()
-	symMap := make(map[string]protocol.DocumentSymbol)
+	symMap := make(map[string]query.Symbol)
 	for _, s := range dep.Symbols() {
 		symMap[s.Name] = s
 	}
 	for _, ls := range load.Symbols {
 		if sym, found := symMap[ls.Name]; found {
 			sym.Name = ls.Alias
-			sym.Range = ls.Range
+			sym.Location = protocol.Location{
+				URI:   d.uri,
+				Range: ls.Range,
+			}
 			d.symbols = append(d.symbols, sym)
 			if f, ok := fns[ls.Name]; ok {
 				d.functions[ls.Alias] = f

--- a/pkg/query/document_content.go
+++ b/pkg/query/document_content.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	sitter "github.com/smacker/go-tree-sitter"
+	"go.lsp.dev/uri"
 )
 
 type DocumentContent interface {
@@ -9,4 +10,5 @@ type DocumentContent interface {
 	Content(n *sitter.Node) string
 	ContentRange(r sitter.Range) string
 	Tree() *sitter.Tree
+	URI() uri.URI
 }

--- a/pkg/query/location.go
+++ b/pkg/query/location.go
@@ -3,6 +3,7 @@ package query
 import (
 	sitter "github.com/smacker/go-tree-sitter"
 	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
 )
 
 // PositionToPoint converts an LSP protocol file location to a Tree-sitter file location.
@@ -18,6 +19,13 @@ func pointToPosition(point sitter.Point) protocol.Position {
 	return protocol.Position{
 		Line:      point.Row,
 		Character: point.Column,
+	}
+}
+
+func NodeLocation(node *sitter.Node, docURI uri.URI) protocol.Location {
+	return protocol.Location{
+		URI:   docURI,
+		Range: NodeRange(node),
 	}
 }
 

--- a/pkg/query/signature.go
+++ b/pkg/query/signature.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"go.lsp.dev/uri"
+
 	"go.lsp.dev/protocol"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -53,6 +55,7 @@ type Signature struct {
 	Params     []Parameter
 	ReturnType string
 	Docs       docstring.Parsed
+	docURI     uri.URI
 	Node       *sitter.Node
 }
 
@@ -95,12 +98,15 @@ func (s Signature) Label() string {
 	return sb.String()
 }
 
-func (s Signature) Symbol() protocol.DocumentSymbol {
-	return protocol.DocumentSymbol{
+func (s Signature) Symbol() Symbol {
+	return Symbol{
 		Name:   s.Name,
 		Kind:   protocol.SymbolKindFunction,
 		Detail: s.Label(),
-		Range:  NodeRange(s.Node),
+		Location: protocol.Location{
+			URI:   s.docURI,
+			Range: NodeRange(s.Node),
+		},
 	}
 }
 

--- a/pkg/server/fixture_test.go
+++ b/pkg/server/fixture_test.go
@@ -269,7 +269,7 @@ func (t *testDocument) Functions() map[string]query.Signature {
 	return t.doc.Functions()
 }
 
-func (t *testDocument) Symbols() []protocol.DocumentSymbol {
+func (t *testDocument) Symbols() []query.Symbol {
 	return t.doc.Symbols()
 }
 
@@ -279,6 +279,10 @@ func (t *testDocument) Diagnostics() []protocol.Diagnostic {
 
 func (t *testDocument) Loads() []document.LoadStatement {
 	return t.doc.Loads()
+}
+
+func (t *testDocument) URI() uri.URI {
+	return uri.New("file://test.txt")
 }
 
 func (t *testDocument) Copy() document.Document {


### PR DESCRIPTION
`query.Symbol` is just a `protocol.DocumentSymbol` but with a `protocol.Location` instead of a `protocol.Range` (i.e., we're just adding a `uri.URI`, specifying which file the symbol is in). This will be used by go to definition/reference.