### PR TITLE
query: inline queries

### DIFF
--- a/pkg/query/conv_test.go
+++ b/pkg/query/conv_test.go
@@ -37,7 +37,7 @@ world"`, "helloworld"},
 	}
 	for i, tt := range cases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			q := newQueryFixture(t, nil, tt[0])
+			q := newQueryFixture(t, "", tt[0])
 			v := query.Unquote(q.input, q.root)
 			assert.Equal(t, tt[1], v)
 		})
@@ -45,7 +45,7 @@ world"`, "helloworld"},
 }
 
 func TestUnquotePanic(t *testing.T) {
-	q := newQueryFixture(t, nil, `hello`)
+	q := newQueryFixture(t, "", `hello`)
 	defer func() {
 		e := recover().(error)
 		assert.NotNil(t, e)

--- a/pkg/query/identifiers.go
+++ b/pkg/query/identifiers.go
@@ -4,6 +4,18 @@ import (
 	sitter "github.com/smacker/go-tree-sitter"
 )
 
+// Extract all identifiers from the subtree. Include an extra empty identifier
+// "" if there is an error node with a trailing period.
+//
+const Identifiers = `
+[(module) @module
+ (identifier) @id
+ "." @dot
+ (ERROR "." @trailing-dot
+	.)
+ ]
+`
+
 func ExtractIdentifiers(doc DocumentContent, nodes []*sitter.Node, limit *sitter.Point) []string {
 	identifiers := []string{}
 

--- a/pkg/query/identifiers.scm
+++ b/pkg/query/identifiers.scm
@@ -1,6 +1,0 @@
-[(module) @module
- (identifier) @id
- "." @dot
- (ERROR "." @trailing-dot
-	.)
- ]

--- a/pkg/query/identifiers_test.go
+++ b/pkg/query/identifiers_test.go
@@ -45,7 +45,7 @@ print("")`, expected: []string{"os", "path", ""}, limit: &sitter.Point{Column: 8
 
 	for _, tt := range tests {
 		t.Run(tt.doc, func(t *testing.T) {
-			f := newQueryFixture(t, []byte{}, tt.doc)
+			f := newQueryFixture(t, "", tt.doc)
 			doc := f.document()
 			ids := query.ExtractIdentifiers(doc, []*sitter.Node{f.tree.RootNode()}, tt.limit)
 			assert.ElementsMatch(t, tt.expected, ids)

--- a/pkg/query/parameters.scm
+++ b/pkg/query/parameters.scm
@@ -1,7 +1,0 @@
-(parameters ([
-    (identifier) @name
-    (_ .
-        (identifier) @name
-        type: (type)? @type
-        value: (expression)? @value)
-]) @param)

--- a/pkg/query/params.go
+++ b/pkg/query/params.go
@@ -12,6 +12,22 @@ import (
 	"github.com/tilt-dev/starlark-lsp/pkg/docstring"
 )
 
+// FunctionParameters extracts parameters from a function definition and
+// supports a mixture of positional parameters, default value parameters,
+// typed parameters*, and typed default value parameters*.
+//
+// * These are not valid Starlark, but we support them to enable using Python
+//   type-stub files for improved editor experience.
+const FunctionParameters = `
+(parameters ([
+    (identifier) @name
+    (_ .
+        (identifier) @name
+        type: (type)? @type
+        value: (expression)? @value)
+]) @param)
+`
+
 type Parameter struct {
 	Name         string
 	TypeHint     string

--- a/pkg/query/queries.go
+++ b/pkg/query/queries.go
@@ -6,24 +6,9 @@ import (
 	sitter "github.com/smacker/go-tree-sitter"
 )
 
-// FunctionParameters extracts parameters from a function definition and
-// supports a mixture of positional parameters, default value parameters,
-// typed parameters*, and typed default value parameters*.
-//
-// * These are not valid Starlark, but we support them to enable using Python
-//   type-stub files for improved editor experience.
-//go:embed parameters.scm
-var FunctionParameters []byte
-
-// Extract all identifiers from the subtree. Include an extra empty identifier
-// "" if there is an error node with a trailing period.
-//
-//go:embed identifiers.scm
-var Identifiers []byte
-
 func LeafNodes(node *sitter.Node) []*sitter.Node {
 	nodes := []*sitter.Node{}
-	Query(node, []byte(`_ @node`), func(q *sitter.Query, match *sitter.QueryMatch) bool {
+	Query(node, `_ @node`, func(q *sitter.Query, match *sitter.QueryMatch) bool {
 		for _, c := range match.Captures {
 			if c.Node.Type() == NodeTypeIdentifier ||
 				(c.Node.ChildCount() == 0 &&
@@ -38,7 +23,7 @@ func LeafNodes(node *sitter.Node) []*sitter.Node {
 
 func LoadStatements(input []byte, tree *sitter.Tree) []*sitter.Node {
 	nodes := []*sitter.Node{}
-	Query(tree.RootNode(), []byte(`(call) @call`), func(q *sitter.Query, match *sitter.QueryMatch) bool {
+	Query(tree.RootNode(), `(call) @call`, func(q *sitter.Query, match *sitter.QueryMatch) bool {
 		for _, c := range match.Captures {
 			id := c.Node.ChildByFieldName("function")
 			name := id.Content(input)

--- a/pkg/query/queries_test.go
+++ b/pkg/query/queries_test.go
@@ -104,7 +104,7 @@ func TestLeafNodes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.src, func(t *testing.T) {
-			q := newQueryFixture(t, []byte{}, tt.src)
+			q := newQueryFixture(t, "", tt.src)
 			nodes := query.LeafNodes(q.root)
 			names := make([]string, len(nodes))
 			types := make([]string, len(nodes))
@@ -120,7 +120,7 @@ func TestLeafNodes(t *testing.T) {
 }
 
 func TestLoadStatements(t *testing.T) {
-	q := newQueryFixture(t, []byte{}, `
+	q := newQueryFixture(t, "", `
 load("file1.star", "foo", "bar")
 if foo():
   load("file2.star", q="quux") # This is not a legal load statement but we still want to capture it
@@ -156,7 +156,7 @@ type queryFixture struct {
 	root  *sitter.Node
 }
 
-func newQueryFixture(t testing.TB, queryPattern []byte, src string) *queryFixture {
+func newQueryFixture(t testing.TB, queryPattern string, src string) *queryFixture {
 	t.Helper()
 
 	lang := python.GetLanguage()
@@ -164,7 +164,7 @@ func newQueryFixture(t testing.TB, queryPattern []byte, src string) *queryFixtur
 	var q *sitter.Query
 	var err error
 	if len(queryPattern) > 0 {
-		q, err = sitter.NewQuery(queryPattern, lang)
+		q, err = sitter.NewQuery([]byte(queryPattern), lang)
 		t.Cleanup(q.Close)
 		require.NoError(t, err, "Error creating query %q", string(queryPattern))
 	}

--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -19,8 +19,8 @@ type MatchFunc func(q *sitter.Query, match *sitter.QueryMatch) bool
 
 // Query executes a Tree-sitter S-expression query against a subtree and invokes
 // matchFn on each result.
-func Query(node *sitter.Node, pattern []byte, matchFn MatchFunc) {
-	q := MustQuery(pattern, LanguagePython)
+func Query(node *sitter.Node, pattern string, matchFn MatchFunc) {
+	q := MustQuery([]byte(pattern), LanguagePython)
 	qc := sitter.NewQueryCursor()
 	defer qc.Close()
 

--- a/pkg/query/symbol_test.go
+++ b/pkg/query/symbol_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestQueryDocumentSymbols(t *testing.T) {
-	f := newQueryFixture(t, []byte{}, `
+	f := newQueryFixture(t, "", `
 x = a(3)
 y = None
 z = True
@@ -26,7 +26,7 @@ z = True
 }
 
 func TestQuerySiblingSymbols(t *testing.T) {
-	f := newQueryFixture(t, []byte{}, `
+	f := newQueryFixture(t, "", `
 def foo():
   bar = 1
   def baz():
@@ -50,7 +50,7 @@ def start():
 }
 
 func TestSymbolsInScope(t *testing.T) {
-	f := newQueryFixture(t, []byte{}, `
+	f := newQueryFixture(t, "", `
 def foo():
   bar = 1
   def baz():
@@ -74,7 +74,7 @@ def start():
 }
 
 func TestSymbolsInScopeExcludesFollowingSiblings(t *testing.T) {
-	f := newQueryFixture(t, []byte{}, `
+	f := newQueryFixture(t, "", `
 def foo():
   bar = 1
   def baz():
@@ -99,7 +99,7 @@ def start():
 }
 
 func TestSymbolsInScopeIncludesFunctionArguments1(t *testing.T) {
-	f := newQueryFixture(t, []byte{}, `
+	f := newQueryFixture(t, "", `
 def foo(a, b=True, c=None):
   bar = 1
   def baz(d):
@@ -120,7 +120,7 @@ def foo(a, b=True, c=None):
 }
 
 func TestSymbolsInScopeIncludesFunctionArguments2(t *testing.T) {
-	f := newQueryFixture(t, []byte{}, `
+	f := newQueryFixture(t, "", `
 def foo(a, b=True, c=None):
   bar = 1
   def baz(d):

--- a/pkg/query/types.go
+++ b/pkg/query/types.go
@@ -35,7 +35,7 @@ func (t Type) FindMethod(name string) (Signature, bool) {
 
 func Types(doc DocumentContent, node *sitter.Node) []Type {
 	types := []Type{}
-	Query(node, []byte(methodsAndFields), func(q *sitter.Query, match *sitter.QueryMatch) bool {
+	Query(node, methodsAndFields, func(q *sitter.Query, match *sitter.QueryMatch) bool {
 		curr := Type{}
 		for _, c := range match.Captures {
 			switch q.CaptureNameForId(c.Index) {

--- a/pkg/query/types_test.go
+++ b/pkg/query/types_test.go
@@ -19,7 +19,7 @@ class Student():
         """Tell student to sleep."""
         pass
 `
-	f := newQueryFixture(t, nil, code)
+	f := newQueryFixture(t, "", code)
 	doc := f.document()
 	classes := query.Types(doc, f.root)
 	assert.Equal(t, 1, len(classes))
@@ -47,7 +47,7 @@ class Student():
     """A sleepy student."""
     pass
 `
-	f := newQueryFixture(t, nil, code)
+	f := newQueryFixture(t, "", code)
 	doc := f.document()
 	classes := query.Types(doc, f.root)
 	assert.Equal(t, 0, len(classes))


### PR DESCRIPTION
As promised.
