### PR TITLE
Fix incorrect circular load

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 
 test:
 ifneq ($(CIRCLECI),true)
-		go test -timeout 30s -v ./...
+	gotestsum -- ./... -timeout 30s
 else
-		mkdir -p test-results
-		gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml -- ./... -timeout 30s
+	mkdir -p test-results
+	gotestsum --format standard-quiet --junitfile test-results/unit-tests.xml -- ./... -timeout 30s
 endif
 
 lint:

--- a/Tiltfile
+++ b/Tiltfile
@@ -20,5 +20,5 @@ make('test', resource_deps=['run'])
 make(
     ['fmt', 'lint', 'tidy', 'install'],
     deps=src_dirs + ['go.mod', 'go.sum'],
-    resource_deps=['test']
+    resource_deps=['run']
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tilt-dev/starlark-lsp
 
-go 1.18
+go 1.19
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/pkg/document/manager.go
+++ b/pkg/document/manager.go
@@ -176,10 +176,8 @@ func (m *Manager) readAndParse(ctx context.Context, u uri.URI, parseState Docume
 }
 
 func (m *Manager) parse(ctx context.Context, uri uri.URI, input []byte, parseState DocumentMap) (doc Document, err error) {
-	cleanup := false
 	if parseState == nil {
 		parseState = make(DocumentMap)
-		cleanup = true
 	}
 
 	if _, parsed := parseState[uri]; parsed {
@@ -200,12 +198,8 @@ func (m *Manager) parse(ctx context.Context, uri uri.URI, input []byte, parseSta
 	if docx, ok := doc.(*document); ok {
 		docx.followLoads(ctx, m, parseState)
 	}
-
-	if cleanup {
-		for u, d := range parseState {
-			m.docs[u] = d
-		}
-	}
+	delete(parseState, uri)
+	m.docs[uri] = doc
 	return doc, err
 }
 

--- a/pkg/document/manager_test.go
+++ b/pkg/document/manager_test.go
@@ -101,6 +101,29 @@ foo = True
 	}
 }
 
+func TestNotCircularLoad(t *testing.T) {
+	f := newFixture(t)
+	require.NoError(t, os.WriteFile("a.tiltfile", []byte(`
+load('ext.tiltfile', 'flag')
+load('b.tiltfile', 'hello')
+hello()
+`), 0644))
+	require.NoError(t, os.WriteFile("b.tiltfile", []byte(`
+load('ext.tiltfile', 'flag')
+
+def hello():
+  print("in b: " + flag)
+`), 0644))
+	require.NoError(t, os.WriteFile("ext.tiltfile", []byte(`
+flag = True
+`), 0644))
+	doc, err := f.m.Read(f.ctx, uri.File("a.tiltfile"))
+	require.NoError(t, err)
+	diags := doc.Diagnostics()
+	fmt.Printf("diags: %v\n", diags)
+	assert.Equal(t, 0, len(diags))
+}
+
 func TestURIfilename(t *testing.T) {
 	var fn string
 	var err error


### PR DESCRIPTION
- chore: use gotestsum in dev
- chore: go 1.19
- chore: fmt-lint-tidy-install only depends on run
- document: clean up parse state at each point of parse stack
