### PR TITLE
Resolve Load Statement Custom URIs

### DIFF
--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -185,21 +185,27 @@ func (d *document) followLoads(ctx context.Context, m *Manager, parseState Docum
 			continue
 		}
 		if !load.processed {
-			d.processLoad(dep, load)
+			d.processLoad(dep, load, m)
 			d.loads[i].processed = true
 		}
 	}
 }
 
-func (d *document) processLoad(dep Document, load LoadStatement) {
+func (d *document) processLoad(dep Document, load LoadStatement, m *Manager) {
 	fns := dep.Functions()
 	symMap := make(map[string]query.Symbol)
+	u, err := m.Resolve(dep.URI())
 	for _, s := range dep.Symbols() {
 		symMap[s.Name] = s
 	}
 	for _, ls := range load.Symbols {
 		if sym, found := symMap[ls.Name]; found {
 			sym.Name = ls.Alias
+			if err == nil {
+				loc := sym.Location
+				loc.URI = u
+				sym.Location = loc
+			}
 			d.symbols = append(d.symbols, sym)
 			if f, ok := fns[ls.Name]; ok {
 				d.functions[ls.Alias] = f

--- a/pkg/document/manager_test.go
+++ b/pkg/document/manager_test.go
@@ -128,7 +128,6 @@ flag = True
 
 func TestResolveURI(t *testing.T) {
 	f := newFixture(t)
-	require.NoError(t, os.Mkdir("exts", 0755))
 	t.Run("default resolve function", func(t *testing.T) {
 		file := uri.File("f.txt")
 		u, err := f.m.Resolve(file)
@@ -159,6 +158,43 @@ func TestResolveURI(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, uri.File(filepath.Join(extsPath, "some", "ext")), u)
 	})
+}
+
+func TestReadLoadResolve(t *testing.T) {
+	f := newFixture(t)
+	require.NoError(t, os.Mkdir("exts", 0755))
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	extsPath := filepath.Join(cwd, "exts")
+	resolve := func(u uri.URI) (string, error) {
+		parsed, err := url.Parse(string(u))
+		if err != nil {
+			return "", err
+		}
+		if parsed.Scheme == "ext" {
+			return filepath.Join(extsPath, parsed.Host, parsed.Path), nil
+		}
+		return ResolveURI(u)
+	}
+	WithResolveURIFunc(resolve)(f.m)
+	WithReadDocumentFunc(func(u uri.URI) ([]byte, error) {
+		file, err := resolve(u)
+		if err != nil {
+			return nil, err
+		}
+		return ReadDocument(uri.File(file))
+	})(f.m)
+
+	hello := filepath.Join(extsPath, "hello")
+	require.NoError(t, os.WriteFile(hello, []byte(`hello = lambda: print('Hi')`), 0644))
+	require.NoError(t, os.WriteFile("doc", []byte("load('ext://hello', 'hello')\nhello()"), 0644))
+
+	doc, err := f.m.Read(f.ctx, uri.File("doc"))
+	require.NoError(t, err)
+	syms := doc.Symbols()
+	assert.Equal(t, 1, len(syms))
+	assert.Equal(t, "hello", syms[0].Name)
+	assert.Equal(t, uri.File(hello), syms[0].Location.URI)
 }
 
 func TestURIfilename(t *testing.T) {


### PR DESCRIPTION
This will make "jump to definition" work to jump inside Tilt extension files.

- document: add manager.Resolve
- document: resolve load statement URIs
