### PR TITLE
Add configurable load paths for load() resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,12 @@ starlark-lsp start --address=":8765"
 # like python modules: subdir/__init__.py and subdir.py define a subdir module.
 starlark-lsp start --builtin-paths "foo.py" --builtin-paths "/tmp/modules"
 
+starlark-lsp start --load-paths "./starlark/api"
+
 Flags:
       --address string              Address (hostname:port) to listen on
       --builtin-paths stringArray   Paths to files and directories to parse and treat as additional language builtins
+      --load-paths stringArray      Directories to search when resolving load statements
   -h, --help                        help for start
 
 Global Flags:

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -23,7 +23,8 @@ import (
 
 type startCmd struct {
 	*cobra.Command
-	address string
+	address   string
+	loadPaths []string
 }
 
 var exampleTemplate = template.Must(template.New("example").Parse(`
@@ -32,6 +33,8 @@ var exampleTemplate = template.Must(template.New("example").Parse(`
 
 # Listen on all interfaces on port 8765
 {{.BaseCommandName}} start --address=":8765"
+
+{{.BaseCommandName}} start --load-paths "./starlark/api"
 {{if .HasBuiltinPathsParam}}
 # Provide type-stub style files to parse and treat as additional language
 # built-ins. If path is a directory, treat files and directories inside
@@ -100,6 +103,11 @@ For socket mode, pass the --address option.
 	cmd.Command.RunE = func(cc *cobra.Command, args []string) error {
 		ctx := cc.Context()
 
+		providedManagerOptions = append([]document.ManagerOpt{}, managerOpts...)
+		if len(cmd.loadPaths) > 0 {
+			providedManagerOptions = append(providedManagerOptions, document.WithLoadPaths(cmd.loadPaths))
+		}
+
 		analyzer, err := createAnalyzer(ctx)
 		if err != nil {
 			return fmt.Errorf("failed to create analyzer: %v", err)
@@ -117,6 +125,8 @@ For socket mode, pass the --address option.
 
 	cmd.Flags().StringVar(&cmd.address, "address", "",
 		"Address (hostname:port) to listen on")
+	cmd.Flags().StringArrayVar(&cmd.loadPaths, "load-paths", nil,
+		"Directories to search when resolving load statements")
 
 	return &cmd
 }

--- a/pkg/document/document.go
+++ b/pkg/document/document.go
@@ -157,7 +157,7 @@ func (d *document) followLoads(ctx context.Context, m *Manager, parseState Docum
 		if load.File == "" {
 			continue
 		}
-		path, err := resolvePath(load.File, d.uri)
+		path, err := m.resolveLoadFunc(load.File, d.uri)
 		var dep Document
 		if err == nil {
 			dep, err = m.readAndParse(ctx, path, parseState)

--- a/pkg/document/manager.go
+++ b/pkg/document/manager.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 
 	"go.lsp.dev/protocol"
@@ -17,24 +18,27 @@ import (
 type ManagerOpt func(manager *Manager)
 type ReadDocumentFunc func(uri.URI) ([]byte, error)
 type ResolveURIFunc func(uri.URI) (string, error)
+type ResolveLoadFunc func(path string, relativeTo uri.URI) (uri.URI, error)
 type DocumentMap map[uri.URI]Document
 
 // Manager provides simplified file read/write operations for the LSP server.
 type Manager struct {
-	mu             sync.Mutex
-	root           uri.URI
-	docs           DocumentMap
-	newDocFunc     NewDocumentFunc
-	readDocFunc    ReadDocumentFunc
-	resolveUriFunc ResolveURIFunc
+	mu              sync.Mutex
+	root            uri.URI
+	docs            DocumentMap
+	newDocFunc      NewDocumentFunc
+	readDocFunc     ReadDocumentFunc
+	resolveUriFunc  ResolveURIFunc
+	resolveLoadFunc ResolveLoadFunc
 }
 
 func NewDocumentManager(opts ...ManagerOpt) *Manager {
 	m := Manager{
-		docs:           make(DocumentMap),
-		newDocFunc:     NewDocument,
-		readDocFunc:    ReadDocument,
-		resolveUriFunc: ResolveURI,
+		docs:            make(DocumentMap),
+		newDocFunc:      NewDocument,
+		readDocFunc:     ReadDocument,
+		resolveUriFunc:  ResolveURI,
+		resolveLoadFunc: ResolveLoad,
 	}
 
 	for _, opt := range opts {
@@ -62,6 +66,45 @@ func WithResolveURIFunc(fn ResolveURIFunc) ManagerOpt {
 	}
 }
 
+func WithResolveLoadFunc(fn ResolveLoadFunc) ManagerOpt {
+	return func(manager *Manager) {
+		manager.resolveLoadFunc = fn
+	}
+}
+
+func WithLoadPaths(paths []string) ManagerOpt {
+	return func(manager *Manager) {
+		var roots []string
+		for _, path := range paths {
+			if path == "" {
+				continue
+			}
+			if abs, err := filepath.Abs(path); err == nil {
+				path = abs
+			}
+			roots = append(roots, filepath.Clean(path))
+		}
+
+		previous := manager.resolveLoadFunc
+		manager.resolveLoadFunc = func(path string, relativeTo uri.URI) (uri.URI, error) {
+			resolved, err := previous(path, relativeTo)
+			if err != nil {
+				return "", err
+			}
+			if loadURIExists(resolved) || !loadPathSearchable(path) {
+				return resolved, nil
+			}
+			for _, root := range roots {
+				candidate := uri.File(filepath.Join(root, filepath.FromSlash(path)))
+				if loadURIExists(candidate) {
+					return candidate, nil
+				}
+			}
+			return resolved, nil
+		}
+	}
+}
+
 // Read the document from the given URI and return its contents. This default
 // implementation of a ReadDocumentFunc only handles file: URIs and returns an
 // error otherwise.
@@ -84,6 +127,26 @@ func ResolveURI(u uri.URI) (string, error) {
 		return "", fmt.Errorf("only file: URLs supported: %s", u)
 	}
 	return u.Filename(), nil
+}
+
+func ResolveLoad(path string, relativeTo uri.URI) (uri.URI, error) {
+	return resolvePath(path, relativeTo)
+}
+
+func loadPathSearchable(path string) bool {
+	return !filepath.IsAbs(path) && !strings.Contains(path, "://")
+}
+
+func loadURIExists(u uri.URI) bool {
+	fn, err := filename(u)
+	if err != nil {
+		return false
+	}
+	info, err := os.Stat(fn)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
 }
 
 func filename(u uri.URI) (fn string, err error) {

--- a/pkg/document/manager_test.go
+++ b/pkg/document/manager_test.go
@@ -41,6 +41,47 @@ func TestReadWithLoad(t *testing.T) {
 	}
 }
 
+func TestReadWithLoadPath(t *testing.T) {
+	f := newFixture(t)
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll("stubs/acme", 0755))
+	require.NoError(t, os.WriteFile("doc1", []byte(`load("acme/api.star", "foo")`), 0644))
+	require.NoError(t, os.WriteFile("stubs/acme/api.star", []byte(`foo = True`), 0644))
+	WithLoadPaths([]string{"stubs"})(f.m)
+
+	doc, err := f.m.Read(f.ctx, uri.File("doc1"))
+	require.NoError(t, err)
+	assert.Empty(t, doc.Diagnostics())
+	syms := doc.Symbols()
+	assert.Equal(t, 1, len(syms))
+	if len(syms) == 1 {
+		assert.Equal(t, "foo", syms[0].Name)
+		assert.Equal(t, uri.File(filepath.Join(cwd, "stubs/acme/api.star")), syms[0].Location.URI)
+	}
+}
+
+func TestReadWithLoadPathPrefersRelativeFile(t *testing.T) {
+	f := newFixture(t)
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll("stubs/acme", 0755))
+	require.NoError(t, os.MkdirAll("acme", 0755))
+	require.NoError(t, os.WriteFile("doc1", []byte(`load("acme/api.star", "foo")`), 0644))
+	require.NoError(t, os.WriteFile("acme/api.star", []byte(`foo = "relative"`), 0644))
+	require.NoError(t, os.WriteFile("stubs/acme/api.star", []byte(`foo = "stub"`), 0644))
+	WithLoadPaths([]string{"stubs"})(f.m)
+
+	doc, err := f.m.Read(f.ctx, uri.File("doc1"))
+	require.NoError(t, err)
+	assert.Empty(t, doc.Diagnostics())
+	syms := doc.Symbols()
+	assert.Equal(t, 1, len(syms))
+	if len(syms) == 1 {
+		assert.Equal(t, uri.File(filepath.Join(cwd, "acme/api.star")), syms[0].Location.URI)
+	}
+}
+
 func TestReadWithUnsupportedURI(t *testing.T) {
 	f := newFixture(t)
 	require.NoError(t, os.WriteFile("doc", []byte(`load("ext://doc2", "foo")`), 0644))


### PR DESCRIPTION
Hi.

Starlark [spec](https://github.com/bazelbuild/starlark/blob/master/spec.md#load-statements) leaves interpretation of load() module strings to the embedding application. This adds optional load path roots so starlark-lsp can resolve logical module paths used by common embedded Starlark setups.
**Existing** relative/absolute file resolution **remains the default**; load paths are searched only when the normal resolved file is not present.

What do you think?